### PR TITLE
Enable auto completion for bash/zsh current session

### DIFF
--- a/cmd/cmds.go
+++ b/cmd/cmds.go
@@ -22,4 +22,5 @@ var Vela = []*cli.Command{
 	&validateCmd,
 	&repairCmd,
 	&chownCmd,
+	&completionCmd,
 }

--- a/cmd/completion.go
+++ b/cmd/completion.go
@@ -1,0 +1,18 @@
+package cmd
+
+import (
+	"github.com/go-vela/cli/cmd/completion"
+	"github.com/urfave/cli/v2"
+)
+
+var completionCmd = cli.Command{
+	Name:        "completion",
+	Category:    "User experience",
+	Aliases:     []string{"c"},
+	Description: "Use this command to enable vela auto completion in your shell.",
+	Usage:       "Enable vela auto completion for the current session. Supports bash & zsh.",
+	Subcommands: []*cli.Command{
+		&completion.BashCmd,
+		&completion.ZSHCmd,
+	},
+}

--- a/cmd/completion/bash.go
+++ b/cmd/completion/bash.go
@@ -1,0 +1,54 @@
+package completion
+
+import (
+	"bytes"
+	"fmt"
+	"github.com/urfave/cli/v2"
+	"os"
+)
+
+var BashCmd = cli.Command{
+	Name:        "bash",
+	Usage:       "Use this command to enable auto completion in bash",
+	Description: "Bash shell auto completion for vela",
+	Action:      executeBash,
+	CustomHelpTemplate: fmt.Sprintf(`%s
+1.  To enable auto completion for current bash session. Make sure bash version is 4+:
+    source <(vela completion bash)
+2.  To permanently enable bash auto completion for vela, visit https://github.com/go-vela/docs
+`, cli.CommandHelpTemplate),
+}
+
+func executeBash(_ *cli.Context) error {
+	buf := new(bytes.Buffer)
+
+	// urfave cli bash auto completion script tailor made for vela
+	buf.WriteString(fmt.Sprintf(`
+	#! /bin/bash
+		_cli_bash_autocomplete() {
+  			if [[ "${COMP_WORDS[0]}" != "source" ]]; then
+    			local cur opts base
+    			COMPREPLY=()
+    			cur="${COMP_WORDS[COMP_CWORD]}"
+    			
+				if [[ "$cur" == "-"* ]]; then
+      				opts=$( ${COMP_WORDS[@]:0:$COMP_CWORD} ${cur} --generate-bash-completion )
+    			else
+      				opts=$( ${COMP_WORDS[@]:0:$COMP_CWORD} --generate-bash-completion )
+    			fi
+    			
+				COMPREPLY=( $(compgen -W "${opts}" -- ${cur}) )
+    			return 0
+  			fi
+		}
+		complete -o bashdefault -o default -o nospace -F _cli_bash_autocomplete vela
+`),
+	)
+
+	_, err := os.Stdout.Write(buf.Bytes())
+
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/cmd/completion/bash.go
+++ b/cmd/completion/bash.go
@@ -16,10 +16,11 @@ var BashCmd = cli.Command{
 	CustomHelpTemplate: fmt.Sprintf(`%s
 1.  To enable auto completion for current bash session. Make sure bash version is 4+:
     source <(vela completion bash)
-2.  To permanently enable bash auto completion for vela, visit https://github.com/go-vela/docs
+2.  To permanently enable bash auto completion for vela, visit https://go-vela.github.io/docs/cli/autocompletion/bash/
 `, cli.CommandHelpTemplate),
 }
 
+// To generate bash completion script which can be sourced to enable vela auto completion in bash shell
 func executeBash(_ *cli.Context) error {
 	buf := new(bytes.Buffer)
 

--- a/cmd/completion/bash.go
+++ b/cmd/completion/bash.go
@@ -3,8 +3,9 @@ package completion
 import (
 	"bytes"
 	"fmt"
-	"github.com/urfave/cli/v2"
 	"os"
+
+	"github.com/urfave/cli/v2"
 )
 
 var BashCmd = cli.Command{
@@ -23,8 +24,7 @@ func executeBash(_ *cli.Context) error {
 	buf := new(bytes.Buffer)
 
 	// urfave cli bash auto completion script tailor made for vela
-	buf.WriteString(fmt.Sprintf(`
-	#! /bin/bash
+	buf.WriteString(`#! /bin/bash
 		_cli_bash_autocomplete() {
   			if [[ "${COMP_WORDS[0]}" != "source" ]]; then
     			local cur opts base
@@ -41,8 +41,7 @@ func executeBash(_ *cli.Context) error {
     			return 0
   			fi
 		}
-		complete -o bashdefault -o default -o nospace -F _cli_bash_autocomplete vela
-`),
+		complete -o bashdefault -o default -o nospace -F _cli_bash_autocomplete vela`,
 	)
 
 	_, err := os.Stdout.Write(buf.Bytes())
@@ -50,5 +49,6 @@ func executeBash(_ *cli.Context) error {
 	if err != nil {
 		return err
 	}
+
 	return nil
 }

--- a/cmd/completion/zsh.go
+++ b/cmd/completion/zsh.go
@@ -3,8 +3,9 @@ package completion
 import (
 	"bytes"
 	"fmt"
-	"github.com/urfave/cli/v2"
 	"os"
+
+	"github.com/urfave/cli/v2"
 )
 
 var ZSHCmd = cli.Command{
@@ -23,9 +24,7 @@ func executeZSH(_ *cli.Context) error {
 	buf := new(bytes.Buffer)
 
 	// urfave cli zsh auto completion script tailor made for vela
-	buf.WriteString(fmt.Sprintf(
-		`#comdef vela
-    	
+	buf.WriteString(`#comdef vela
 		_cli_zsh_autocomplete() {
   			local -a opts
   			local cur
@@ -45,12 +44,12 @@ func executeZSH(_ *cli.Context) error {
 		}
 		export _CLI_ZSH_AUTOCOMPLETE_HACK=1
 		compdef _cli_zsh_autocomplete vela`,
-	),
 	)
 
 	_, err := os.Stdout.Write(buf.Bytes())
 	if err != nil {
 		return err
 	}
+
 	return nil
 }

--- a/cmd/completion/zsh.go
+++ b/cmd/completion/zsh.go
@@ -1,0 +1,56 @@
+package completion
+
+import (
+	"bytes"
+	"fmt"
+	"github.com/urfave/cli/v2"
+	"os"
+)
+
+var ZSHCmd = cli.Command{
+	Name:        "zsh",
+	Usage:       "Use this command to enable auto completion in zsh",
+	Description: "zsh shell auto completion for vela",
+	Action:      executeZSH,
+	CustomHelpTemplate: fmt.Sprintf(`%s
+1.  To enable auto completion for current zsh session:
+    source <(vela completion zsh)
+2.  To permanently enable zsh auto completion for vela, visit https://github.com/go-vela/docs
+`, cli.CommandHelpTemplate),
+}
+
+func executeZSH(_ *cli.Context) error {
+	buf := new(bytes.Buffer)
+
+	// urfave cli zsh auto completion script tailor made for vela
+	buf.WriteString(fmt.Sprintf(
+		`#comdef vela
+    	
+		_cli_zsh_autocomplete() {
+  			local -a opts
+  			local cur
+  			cur=${words[-1]}
+  			
+			if [[ "$cur" == "-"* ]]; then
+    			opts=("${(@f)$(_CLI_ZSH_AUTOCOMPLETE_HACK=1 ${words[@]:0:#words[@]-1} ${cur} --generate-bash-completion)}")
+			else
+    			opts=("${(@f)$(_CLI_ZSH_AUTOCOMPLETE_HACK=1 ${words[@]:0:#words[@]-1} --generate-bash-completion)}")
+  			fi
+  			
+			if [[ "${opts[1]}" != "" ]]; then
+   		  		_describe 'values' opts
+  			fi
+
+  			return
+		}
+		export _CLI_ZSH_AUTOCOMPLETE_HACK=1
+		compdef _cli_zsh_autocomplete vela`,
+	),
+	)
+
+	_, err := os.Stdout.Write(buf.Bytes())
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/cmd/completion/zsh.go
+++ b/cmd/completion/zsh.go
@@ -16,10 +16,11 @@ var ZSHCmd = cli.Command{
 	CustomHelpTemplate: fmt.Sprintf(`%s
 1.  To enable auto completion for current zsh session:
     source <(vela completion zsh)
-2.  To permanently enable zsh auto completion for vela, visit https://github.com/go-vela/docs
+2.  To permanently enable zsh auto completion for vela, visit https://go-vela.github.io/docs/cli/autocompletion/zsh/
 `, cli.CommandHelpTemplate),
 }
 
+// To generate zsh completion script which can be sourced to enable vela auto completion in zsh shell
 func executeZSH(_ *cli.Context) error {
 	buf := new(bytes.Buffer)
 

--- a/cmd/vela-cli/main.go
+++ b/cmd/vela-cli/main.go
@@ -26,6 +26,7 @@ func main() {
 	}
 
 	app := cli.NewApp()
+	app.EnableBashCompletion = true
 	app.Name = "vela"
 	app.HelpName = "vela"
 	app.Usage = "CLI for managing Vela resources"


### PR DESCRIPTION
This resolves https://github.com/go-vela/community/issues/19

**source <(vela completion bash)**           _Make sure bash version is 4 or above_
or
**source <(vela completion zsh)**

This will enable auto completion for the current zsh/bash session. To enable it permanently, we would need to copy the script to /etc/bash-completion.d

zsh snapshots:
<img width="1680" alt="image" src="https://user-images.githubusercontent.com/41874936/85245779-48137d00-b40e-11ea-866a-92fae0ecc65a.png">

<img width="1680" alt="image" src="https://user-images.githubusercontent.com/41874936/85245815-5d88a700-b40e-11ea-9c97-4ca108f562a9.png">

bash snapshots:
<img width="1680" alt="image" src="https://user-images.githubusercontent.com/41874936/85245835-6da08680-b40e-11ea-979d-f2f49117878b.png">

<img width="1680" alt="image" src="https://user-images.githubusercontent.com/41874936/85245844-77c28500-b40e-11ea-923b-77a7a9c9181e.png">


