### PR TITLE
improve(log): add extra output methods

### DIFF
--- a/action/log/get.go
+++ b/action/log/get.go
@@ -20,13 +20,25 @@ func (c *Config) Get(client *vela.Client) error {
 
 	// handle the output based off the provided configuration
 	switch c.Output {
-	case "json":
+	case output.DriverDump:
+		// output the build logs in dump format
+		err := output.Dump(logs)
+		if err != nil {
+			return err
+		}
+	case output.DriverJSON:
 		// output the build logs in JSON format
 		err := output.JSON(logs)
 		if err != nil {
 			return err
 		}
-	case "yaml":
+	case output.DriverSpew:
+		// output the build logs in spew format
+		err := output.Spew(logs)
+		if err != nil {
+			return err
+		}
+	case output.DriverYAML:
 		// output the build logs in YAML format
 		err := output.YAML(logs)
 		if err != nil {

--- a/action/log/get_test.go
+++ b/action/log/get_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/go-vela/sdk-go/vela"
 )
 
-func TestService_Config_Get(t *testing.T) {
+func TestLog_Config_Get(t *testing.T) {
 	// setup test server
 	s := httptest.NewServer(server.FakeHandler())
 
@@ -35,7 +35,17 @@ func TestService_Config_Get(t *testing.T) {
 				Org:    "github",
 				Repo:   "octocat",
 				Build:  1,
-				Output: "default",
+				Output: "",
+			},
+		},
+		{
+			failure: false,
+			config: &Config{
+				Action: "get",
+				Org:    "github",
+				Repo:   "octocat",
+				Build:  1,
+				Output: "dump",
 			},
 		},
 		{
@@ -46,6 +56,16 @@ func TestService_Config_Get(t *testing.T) {
 				Repo:   "octocat",
 				Build:  1,
 				Output: "json",
+			},
+		},
+		{
+			failure: false,
+			config: &Config{
+				Action: "get",
+				Org:    "github",
+				Repo:   "octocat",
+				Build:  1,
+				Output: "spew",
 			},
 		},
 		{

--- a/action/log/validate_test.go
+++ b/action/log/validate_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 )
 
-func TestService_Config_Validate(t *testing.T) {
+func TestLog_Config_Validate(t *testing.T) {
 	// setup tests
 	tests := []struct {
 		failure bool
@@ -21,7 +21,7 @@ func TestService_Config_Validate(t *testing.T) {
 				Org:    "github",
 				Repo:   "octocat",
 				Build:  1,
-				Output: "default",
+				Output: "",
 			},
 		},
 		{
@@ -32,7 +32,7 @@ func TestService_Config_Validate(t *testing.T) {
 				Repo:    "octocat",
 				Build:   1,
 				Service: 1,
-				Output:  "default",
+				Output:  "",
 			},
 		},
 		{
@@ -43,7 +43,7 @@ func TestService_Config_Validate(t *testing.T) {
 				Repo:   "octocat",
 				Build:  1,
 				Step:   1,
-				Output: "default",
+				Output: "",
 			},
 		},
 		{
@@ -54,7 +54,7 @@ func TestService_Config_Validate(t *testing.T) {
 				Repo:   "octocat",
 				Build:  1,
 				Step:   1,
-				Output: "default",
+				Output: "",
 			},
 		},
 		{
@@ -65,7 +65,7 @@ func TestService_Config_Validate(t *testing.T) {
 				Repo:   "",
 				Build:  1,
 				Step:   1,
-				Output: "default",
+				Output: "",
 			},
 		},
 		{
@@ -76,7 +76,7 @@ func TestService_Config_Validate(t *testing.T) {
 				Repo:   "octocat",
 				Build:  0,
 				Step:   1,
-				Output: "default",
+				Output: "",
 			},
 		},
 	}

--- a/action/log/view.go
+++ b/action/log/view.go
@@ -20,13 +20,25 @@ func (c *Config) ViewService(client *vela.Client) error {
 
 	// handle the output based off the provided configuration
 	switch c.Output {
-	case "json":
+	case output.DriverDump:
+		// output the service log in dump format
+		err := output.Dump(log)
+		if err != nil {
+			return err
+		}
+	case output.DriverJSON:
 		// output the service log in JSON format
 		err := output.JSON(log)
 		if err != nil {
 			return err
 		}
-	case "yaml":
+	case output.DriverSpew:
+		// output the service log in spew format
+		err := output.Spew(log)
+		if err != nil {
+			return err
+		}
+	case output.DriverYAML:
 		// output the service log in YAML format
 		err := output.YAML(log)
 		if err != nil {
@@ -53,13 +65,25 @@ func (c *Config) ViewStep(client *vela.Client) error {
 
 	// handle the output based off the provided configuration
 	switch c.Output {
-	case "json":
+	case output.DriverDump:
+		// output the step log in dump format
+		err := output.Dump(log)
+		if err != nil {
+			return err
+		}
+	case output.DriverJSON:
 		// output the step log in JSON format
 		err := output.JSON(log)
 		if err != nil {
 			return err
 		}
-	case "yaml":
+	case output.DriverSpew:
+		// output the step log in spew format
+		err := output.Spew(log)
+		if err != nil {
+			return err
+		}
+	case output.DriverYAML:
 		// output the step log in YAML format
 		err := output.YAML(log)
 		if err != nil {

--- a/action/log/view_test.go
+++ b/action/log/view_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/go-vela/sdk-go/vela"
 )
 
-func TestService_Config_ViewService(t *testing.T) {
+func TestLog_Config_ViewService(t *testing.T) {
 	// setup test server
 	s := httptest.NewServer(server.FakeHandler())
 
@@ -36,7 +36,18 @@ func TestService_Config_ViewService(t *testing.T) {
 				Repo:    "octocat",
 				Build:   1,
 				Service: 1,
-				Output:  "default",
+				Output:  "",
+			},
+		},
+		{
+			failure: false,
+			config: &Config{
+				Action:  "view",
+				Org:     "github",
+				Repo:    "octocat",
+				Build:   1,
+				Service: 1,
+				Output:  "dump",
 			},
 		},
 		{
@@ -58,6 +69,17 @@ func TestService_Config_ViewService(t *testing.T) {
 				Repo:    "octocat",
 				Build:   1,
 				Service: 1,
+				Output:  "spew",
+			},
+		},
+		{
+			failure: false,
+			config: &Config{
+				Action:  "view",
+				Org:     "github",
+				Repo:    "octocat",
+				Build:   1,
+				Service: 1,
 				Output:  "yaml",
 			},
 		},
@@ -68,7 +90,7 @@ func TestService_Config_ViewService(t *testing.T) {
 				Org:    "github",
 				Repo:   "octocat",
 				Build:  1,
-				Output: "default",
+				Output: "",
 			},
 		},
 	}
@@ -114,7 +136,18 @@ func TestService_Config_ViewStep(t *testing.T) {
 				Repo:   "octocat",
 				Build:  1,
 				Step:   1,
-				Output: "default",
+				Output: "",
+			},
+		},
+		{
+			failure: false,
+			config: &Config{
+				Action: "view",
+				Org:    "github",
+				Repo:   "octocat",
+				Build:  1,
+				Step:   1,
+				Output: "dump",
 			},
 		},
 		{
@@ -136,6 +169,17 @@ func TestService_Config_ViewStep(t *testing.T) {
 				Repo:   "octocat",
 				Build:  1,
 				Step:   1,
+				Output: "spew",
+			},
+		},
+		{
+			failure: false,
+			config: &Config{
+				Action: "view",
+				Org:    "github",
+				Repo:   "octocat",
+				Build:  1,
+				Step:   1,
 				Output: "yaml",
 			},
 		},
@@ -146,7 +190,7 @@ func TestService_Config_ViewStep(t *testing.T) {
 				Org:    "github",
 				Repo:   "octocat",
 				Build:  1,
-				Output: "default",
+				Output: "",
 			},
 		},
 	}


### PR DESCRIPTION
* Added `go-vela/cli/internal/output.Dump` as an output option
* Added `go-vela/cli/internal/output.Spew` as an output option
* Fixed some typos in the tests for this package