### PR TITLE
refactor: rename output.Default to output.Stdout

### DIFF
--- a/action/build/restart.go
+++ b/action/build/restart.go
@@ -45,8 +45,8 @@ func (c *Config) Restart(client *vela.Client) error {
 			return err
 		}
 	default:
-		// output the build in default format
-		err := output.Default(build)
+		// output the build in stdout format
+		err := output.Stdout(build)
 		if err != nil {
 			return err
 		}

--- a/action/build/table.go
+++ b/action/build/table.go
@@ -43,8 +43,8 @@ func table(builds *[]library.Build) error {
 		table.AddRow(b.GetNumber(), b.GetStatus(), b.GetEvent(), b.GetBranch(), d)
 	}
 
-	// output the table in default format
-	err := output.Default(table)
+	// output the table in stdout format
+	err := output.Stdout(table)
 	if err != nil {
 		return err
 	}
@@ -83,8 +83,8 @@ func wideTable(builds *[]library.Build) error {
 		table.AddRow(b.GetNumber(), b.GetStatus(), b.GetEvent(), b.GetBranch(), b.GetCommit(), d, c, f, b.GetAuthor())
 	}
 
-	// output the wide table in default format
-	err := output.Default(table)
+	// output the wide table in stdout format
+	err := output.Stdout(table)
 	if err != nil {
 		return err
 	}

--- a/action/build/view.go
+++ b/action/build/view.go
@@ -45,8 +45,8 @@ func (c *Config) View(client *vela.Client) error {
 			return err
 		}
 	default:
-		// output the build in default format
-		err := output.Default(build)
+		// output the build in stdout format
+		err := output.Stdout(build)
 		if err != nil {
 			return err
 		}

--- a/action/deployment/add.go
+++ b/action/deployment/add.go
@@ -55,8 +55,8 @@ func (c *Config) Add(client *vela.Client) error {
 			return err
 		}
 	default:
-		// output the deployment in default format
-		err := output.Default(deployment)
+		// output the deployment in stdout format
+		err := output.Stdout(deployment)
 		if err != nil {
 			return err
 		}

--- a/action/deployment/table.go
+++ b/action/deployment/table.go
@@ -36,8 +36,8 @@ func table(deployments *[]library.Deployment) error {
 		table.AddRow(d.GetID(), d.GetTask(), d.GetUser(), d.GetRef(), d.GetTarget())
 	}
 
-	// output the table in default format
-	err := output.Default(table)
+	// output the table in stdout format
+	err := output.Stdout(table)
 	if err != nil {
 		return err
 	}
@@ -67,8 +67,8 @@ func wideTable(deployments *[]library.Deployment) error {
 		table.AddRow(d.GetID(), d.GetTask(), d.GetUser(), d.GetRef(), d.GetTarget(), d.GetCommit(), d.GetDescription())
 	}
 
-	// output the wide table in default format
-	err := output.Default(table)
+	// output the wide table in stdout format
+	err := output.Stdout(table)
 	if err != nil {
 		return err
 	}

--- a/action/deployment/view.go
+++ b/action/deployment/view.go
@@ -45,8 +45,8 @@ func (c *Config) View(client *vela.Client) error {
 			return err
 		}
 	default:
-		// output the deployment in default format
-		err := output.Default(deployment)
+		// output the deployment in stdout format
+		err := output.Stdout(deployment)
 		if err != nil {
 			return err
 		}

--- a/action/hook/table.go
+++ b/action/hook/table.go
@@ -41,8 +41,8 @@ func table(hooks *[]library.Hook) error {
 		table.AddRow(h.GetNumber(), h.GetStatus(), h.GetEvent(), h.GetBranch(), c)
 	}
 
-	// output the table in default format
-	err := output.Default(table)
+	// output the table in stdout format
+	err := output.Stdout(table)
 	if err != nil {
 		return err
 	}
@@ -75,8 +75,8 @@ func wideTable(hooks *[]library.Hook) error {
 		table.AddRow(h.GetNumber(), h.GetSourceID(), h.GetStatus(), h.GetHost(), h.GetEvent(), h.GetBranch(), c)
 	}
 
-	// output the wide table in default format
-	err := output.Default(table)
+	// output the wide table in stdout format
+	err := output.Stdout(table)
 	if err != nil {
 		return err
 	}

--- a/action/hook/view.go
+++ b/action/hook/view.go
@@ -45,8 +45,8 @@ func (c *Config) View(client *vela.Client) error {
 			return err
 		}
 	default:
-		// output the hook in default format
-		err := output.Default(hook)
+		// output the hook in stdout format
+		err := output.Stdout(hook)
 		if err != nil {
 			return err
 		}

--- a/action/log/get.go
+++ b/action/log/get.go
@@ -45,8 +45,8 @@ func (c *Config) Get(client *vela.Client) error {
 			return err
 		}
 	default:
-		// output the build logs in default format
-		err := output.Default(logs)
+		// output the build logs in stdout format
+		err := output.Stdout(logs)
 		if err != nil {
 			return err
 		}

--- a/action/log/view.go
+++ b/action/log/view.go
@@ -45,8 +45,8 @@ func (c *Config) ViewService(client *vela.Client) error {
 			return err
 		}
 	default:
-		// output the service log in default format
-		err := output.Default(log)
+		// output the service log in stdout format
+		err := output.Stdout(log)
 		if err != nil {
 			return err
 		}
@@ -90,8 +90,8 @@ func (c *Config) ViewStep(client *vela.Client) error {
 			return err
 		}
 	default:
-		// output the step log in default format
-		err := output.Default(log)
+		// output the step log in stdout format
+		err := output.Stdout(log)
 		if err != nil {
 			return err
 		}

--- a/action/repo/add.go
+++ b/action/repo/add.go
@@ -86,8 +86,8 @@ func (c *Config) Add(client *vela.Client) error {
 			return err
 		}
 	default:
-		// output the repository in default format
-		err := output.Default(repo)
+		// output the repository in stdout format
+		err := output.Stdout(repo)
 		if err != nil {
 			return err
 		}

--- a/action/repo/chown.go
+++ b/action/repo/chown.go
@@ -45,8 +45,8 @@ func (c *Config) Chown(client *vela.Client) error {
 			return err
 		}
 	default:
-		// output the message in default format
-		err := output.Default(msg)
+		// output the message in stdout format
+		err := output.Stdout(msg)
 		if err != nil {
 			return err
 		}

--- a/action/repo/remove.go
+++ b/action/repo/remove.go
@@ -45,8 +45,8 @@ func (c *Config) Remove(client *vela.Client) error {
 			return err
 		}
 	default:
-		// output the message in default format
-		err := output.Default(msg)
+		// output the message in stdout format
+		err := output.Stdout(msg)
 		if err != nil {
 			return err
 		}

--- a/action/repo/repair.go
+++ b/action/repo/repair.go
@@ -45,8 +45,8 @@ func (c *Config) Repair(client *vela.Client) error {
 			return err
 		}
 	default:
-		// output the message in default format
-		err := output.Default(msg)
+		// output the message in stdout format
+		err := output.Stdout(msg)
 		if err != nil {
 			return err
 		}

--- a/action/repo/table.go
+++ b/action/repo/table.go
@@ -39,8 +39,8 @@ func table(repos *[]library.Repo) error {
 		table.AddRow(r.GetFullName(), r.GetActive(), e, r.GetVisibility(), r.GetBranch())
 	}
 
-	// output the table in default format
-	err := output.Default(table)
+	// output the table in stdout format
+	err := output.Stdout(table)
 	if err != nil {
 		return err
 	}
@@ -72,8 +72,8 @@ func wideTable(repos *[]library.Repo) error {
 		table.AddRow(r.GetFullName(), r.GetActive(), e, r.GetVisibility(), r.GetBranch(), r.GetLink())
 	}
 
-	// output the wide table in default format
-	err := output.Default(table)
+	// output the wide table in stdout format
+	err := output.Stdout(table)
 	if err != nil {
 		return err
 	}

--- a/action/repo/update.go
+++ b/action/repo/update.go
@@ -86,8 +86,8 @@ func (c *Config) Update(client *vela.Client) error {
 			return err
 		}
 	default:
-		// output the repository in default format
-		err := output.Default(repo)
+		// output the repository in stdout format
+		err := output.Stdout(repo)
 		if err != nil {
 			return err
 		}

--- a/action/repo/view.go
+++ b/action/repo/view.go
@@ -45,8 +45,8 @@ func (c *Config) View(client *vela.Client) error {
 			return err
 		}
 	default:
-		// output the repository in default format
-		err := output.Default(repo)
+		// output the repository in stdout format
+		err := output.Stdout(repo)
 		if err != nil {
 			return err
 		}

--- a/action/secret/add.go
+++ b/action/secret/add.go
@@ -83,8 +83,8 @@ func (c *Config) Add(client *vela.Client) error {
 			return err
 		}
 	default:
-		// output the secret in default format
-		err := output.Default(secret)
+		// output the secret in stdout format
+		err := output.Stdout(secret)
 		if err != nil {
 			return err
 		}

--- a/action/secret/remove.go
+++ b/action/secret/remove.go
@@ -64,8 +64,8 @@ func (c *Config) Remove(client *vela.Client) error {
 			return err
 		}
 	default:
-		// output the message in default format
-		err := output.Default(msg)
+		// output the message in stdout format
+		err := output.Stdout(msg)
 		if err != nil {
 			return err
 		}

--- a/action/secret/table.go
+++ b/action/secret/table.go
@@ -41,8 +41,8 @@ func table(secrets *[]library.Secret) error {
 		table.AddRow(s.GetName(), s.GetOrg(), s.GetType(), k)
 	}
 
-	// output the table in default format
-	err := output.Default(table)
+	// output the table in stdout format
+	err := output.Stdout(table)
 	if err != nil {
 		return err
 	}
@@ -81,8 +81,8 @@ func wideTable(secrets *[]library.Secret) error {
 		table.AddRow(s.GetName(), s.GetOrg(), s.GetType(), k, e, i)
 	}
 
-	// output the wide table in default format
-	err := output.Default(table)
+	// output the wide table in stdout format
+	err := output.Stdout(table)
 	if err != nil {
 		return err
 	}

--- a/action/secret/update.go
+++ b/action/secret/update.go
@@ -83,8 +83,8 @@ func (c *Config) Update(client *vela.Client) error {
 			return err
 		}
 	default:
-		// output the secret in default format
-		err := output.Default(secret)
+		// output the secret in stdout format
+		err := output.Stdout(secret)
 		if err != nil {
 			return err
 		}

--- a/action/secret/view.go
+++ b/action/secret/view.go
@@ -64,8 +64,8 @@ func (c *Config) View(client *vela.Client) error {
 			return err
 		}
 	default:
-		// output the secret in default format
-		err := output.Default(secret)
+		// output the secret in stdout format
+		err := output.Stdout(secret)
 		if err != nil {
 			return err
 		}

--- a/action/service/table.go
+++ b/action/service/table.go
@@ -43,8 +43,8 @@ func table(services *[]library.Service) error {
 		table.AddRow(s.GetNumber(), s.GetName(), s.GetStatus(), d)
 	}
 
-	// output the table in default format
-	err := output.Default(table)
+	// output the table in stdout format
+	err := output.Stdout(table)
 	if err != nil {
 		return err
 	}
@@ -83,8 +83,8 @@ func wideTable(services *[]library.Service) error {
 		table.AddRow(s.GetNumber(), s.GetName(), s.GetStatus(), d, c, f)
 	}
 
-	// output the wide table in default format
-	err := output.Default(table)
+	// output the wide table in stdout format
+	err := output.Stdout(table)
 	if err != nil {
 		return err
 	}

--- a/action/service/view.go
+++ b/action/service/view.go
@@ -45,8 +45,8 @@ func (c *Config) View(client *vela.Client) error {
 			return err
 		}
 	default:
-		// output the service in default format
-		err := output.Default(service)
+		// output the service in stdout format
+		err := output.Stdout(service)
 		if err != nil {
 			return err
 		}

--- a/action/step/table.go
+++ b/action/step/table.go
@@ -43,8 +43,8 @@ func table(steps *[]library.Step) error {
 		table.AddRow(s.GetNumber(), s.GetName(), s.GetStatus(), d)
 	}
 
-	// output the table in default format
-	err := output.Default(table)
+	// output the table in stdout format
+	err := output.Stdout(table)
 	if err != nil {
 		return err
 	}
@@ -83,8 +83,8 @@ func wideTable(steps *[]library.Step) error {
 		table.AddRow(s.GetNumber(), s.GetName(), s.GetStatus(), d, c, f)
 	}
 
-	// output the wide table in default format
-	err := output.Default(table)
+	// output the wide table in stdout format
+	err := output.Stdout(table)
 	if err != nil {
 		return err
 	}

--- a/action/step/view.go
+++ b/action/step/view.go
@@ -45,8 +45,8 @@ func (c *Config) View(client *vela.Client) error {
 			return err
 		}
 	default:
-		// output the step in default format
-		err := output.Default(step)
+		// output the step in stdout format
+		err := output.Stdout(step)
 		if err != nil {
 			return err
 		}

--- a/internal/output/driver.go
+++ b/internal/output/driver.go
@@ -6,9 +6,9 @@ package output
 
 // output drivers
 const (
-	// DriverDefault defines the driver type
-	// when outputting in default format.
-	DriverDefault = "default"
+	// DriverStdout defines the driver type
+	// when outputting in stdout format.
+	DriverStdout = "stdout"
 
 	// DriverDump defines the driver type
 	// when outputting in dump format.

--- a/internal/output/stdout.go
+++ b/internal/output/stdout.go
@@ -11,17 +11,17 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-// Default outputs the provided input to stdout.
-func Default(_input interface{}) error {
-	logrus.Debugf("creating output with %s driver", DriverDefault)
+// Stdout outputs the provided input to stdout.
+func Stdout(_input interface{}) error {
+	logrus.Debugf("creating output with %s driver", DriverStdout)
 
 	// validate the input provided
-	err := validate(DriverDefault, _input)
+	err := validate(DriverStdout, _input)
 	if err != nil {
 		return err
 	}
 
-	logrus.Tracef("sending output to stdout with %s driver", DriverDefault)
+	logrus.Tracef("sending output to stdout with %s driver", DriverStdout)
 
 	// ensure we output to stdout
 	fmt.Fprintln(os.Stdout, _input)

--- a/internal/output/stdout_test.go
+++ b/internal/output/stdout_test.go
@@ -46,18 +46,18 @@ func TestOutput_Default(t *testing.T) {
 
 	// run tests
 	for _, test := range tests {
-		err := Default(test.input)
+		err := Stdout(test.input)
 
 		if test.failure {
 			if err == nil {
-				t.Errorf("Default should have returned err")
+				t.Errorf("Stdout should have returned err")
 			}
 
 			continue
 		}
 
 		if err != nil {
-			t.Errorf("Default returned err: %v", err)
+			t.Errorf("Stdout returned err: %v", err)
 		}
 	}
 }

--- a/internal/output/validate_test.go
+++ b/internal/output/validate_test.go
@@ -17,37 +17,37 @@ func TestOutput_validate(t *testing.T) {
 	}{
 		{
 			failure: false,
-			driver:  DriverDefault,
+			driver:  DriverStdout,
 			input:   "hello",
 		},
 		{ // map
 			failure: false,
-			driver:  DriverDefault,
+			driver:  DriverStdout,
 			input:   map[string]string{"hello": "world"},
 		},
 		{ // slice
 			failure: false,
-			driver:  DriverDefault,
+			driver:  DriverStdout,
 			input:   []interface{}{1, 2, 3},
 		},
 		{ // slice complex
 			failure: false,
-			driver:  DriverDefault,
+			driver:  DriverStdout,
 			input:   []interface{}{struct{ Foo string }{Foo: "bar"}},
 		},
 		{ // complex
 			failure: false,
-			driver:  DriverDefault,
+			driver:  DriverStdout,
 			input:   []struct{ Foo string }{{"bar"}, {"baz"}},
 		},
 		{
 			failure: true,
-			driver:  DriverDefault,
+			driver:  DriverStdout,
 			input:   nil,
 		},
 		{
 			failure: true,
-			driver:  DriverDefault,
+			driver:  DriverStdout,
 			input:   "",
 		},
 		{


### PR DESCRIPTION
* Refactored `go-vela/cli/internal/output.Default()` to `go-vela/cli/internal/output.Stdout()`
* Updated `go-vela/cli/internal/output.DriverDefault` to `go-vela/cli/internal/output.DriverStdout`
* Updated all functions in `go-vela/cli/action` to use `go-vela/cli/internal/output.Stdout()`