### PR TITLE
feat(internal): add client pkg

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -1,0 +1,47 @@
+// Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+//
+// Use of this source code is governed by the LICENSE file in this repository.
+
+package client
+
+import (
+	"github.com/go-vela/sdk-go/vela"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/urfave/cli/v2"
+)
+
+// Parse digests the provided urfave/cli context
+// and parses the provided configuration to
+// produce a valid Vela client.
+func Parse(c *cli.Context) (*vela.Client, error) {
+	logrus.Debug("parsing Vela client from provided configuration")
+
+	// capture the address from the context
+	address := c.String(KeyAddress)
+
+	// capture the token from the context
+	token := c.String(KeyToken)
+
+	// validate the provided configuration
+	err := validate(address, token)
+	if err != nil {
+		return nil, err
+	}
+
+	logrus.Tracef("creating Vela client for %s", address)
+
+	// create a vela client from the provided address
+	client, err := vela.NewClient(address, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	logrus.Trace("setting token for Vela client")
+
+	// set the authentication mechanism from the provided token
+	client.Authentication.SetTokenAuth(token)
+
+	return client, nil
+}

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -1,0 +1,67 @@
+// Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+//
+// Use of this source code is governed by the LICENSE file in this repository.
+
+package client
+
+import (
+	"flag"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-vela/mock/server"
+
+	"github.com/urfave/cli/v2"
+)
+
+func TestClient_Parse(t *testing.T) {
+	// setup test server
+	s := httptest.NewServer(server.FakeHandler())
+
+	// setup flags
+	serverSet := flag.NewFlagSet("test", 0)
+	serverSet.String("addr", s.URL, "doc")
+
+	tokenSet := flag.NewFlagSet("test", 0)
+	tokenSet.String("token", "superSecretToken", "doc")
+
+	fullSet := flag.NewFlagSet("test", 0)
+	fullSet.String("addr", s.URL, "doc")
+	fullSet.String("token", "superSecretToken", "doc")
+
+	// setup tests
+	tests := []struct {
+		failure bool
+		set     *flag.FlagSet
+	}{
+		{
+			failure: false,
+			set:     fullSet,
+		},
+		{
+			failure: true,
+			set:     serverSet,
+		},
+		{
+			failure: true,
+			set:     tokenSet,
+		},
+	}
+
+	// run tests
+	for _, test := range tests {
+		_, err := Parse(cli.NewContext(nil, test.set, nil))
+
+		if test.failure {
+			if err == nil {
+				t.Errorf("Parse should have returned err")
+			}
+
+			continue
+		}
+
+		if err != nil {
+			t.Errorf("Parse returned err: %v", err)
+		}
+	}
+}

--- a/internal/client/doc.go
+++ b/internal/client/doc.go
@@ -1,0 +1,11 @@
+// Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+//
+// Use of this source code is governed by the LICENSE file in this repository.
+
+// Package client provides the ability for Vela to parse
+// and manage the client rendered for a CLI action.
+//
+// Usage:
+//
+// 	import "github.com/go-vela/cli/internal/client"
+package client

--- a/internal/client/key.go
+++ b/internal/client/key.go
@@ -1,0 +1,16 @@
+// Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+//
+// Use of this source code is governed by the LICENSE file in this repository.
+
+package client
+
+// client flag keys
+const (
+	// KeyAddress defines the flag key
+	// when parsing the client address.
+	KeyAddress = "addr"
+
+	// KeyToken defines the client key
+	// when parsing the client token.
+	KeyToken = "token"
+)

--- a/internal/client/validate.go
+++ b/internal/client/validate.go
@@ -1,0 +1,28 @@
+// Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+//
+// Use of this source code is governed by the LICENSE file in this repository.
+
+package client
+
+import (
+	"fmt"
+
+	"github.com/sirupsen/logrus"
+)
+
+// validate is a helper function to verify the input provided.
+func validate(address, token string) error {
+	logrus.Debug("validating provided configuration for Vela client")
+
+	// check if client address is set
+	if len(address) == 0 {
+		return fmt.Errorf("no client address provided")
+	}
+
+	// check if client token is set
+	if len(token) == 0 {
+		return fmt.Errorf("no client token provided")
+	}
+
+	return nil
+}

--- a/internal/client/validate_test.go
+++ b/internal/client/validate_test.go
@@ -1,0 +1,57 @@
+// Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+//
+// Use of this source code is governed by the LICENSE file in this repository.
+
+package client
+
+import (
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-vela/mock/server"
+)
+
+func TestClient_validate(t *testing.T) {
+	// setup test server
+	s := httptest.NewServer(server.FakeHandler())
+
+	// setup tests
+	tests := []struct {
+		failure bool
+		address string
+		token   string
+	}{
+		{
+			failure: false,
+			address: s.URL,
+			token:   "superSecretToken",
+		},
+		{
+			failure: true,
+			address: "",
+			token:   "superSecretToken",
+		},
+		{
+			failure: true,
+			address: s.URL,
+			token:   "",
+		},
+	}
+
+	// run tests
+	for _, test := range tests {
+		err := validate(test.address, test.token)
+
+		if test.failure {
+			if err == nil {
+				t.Errorf("validate should have returned err")
+			}
+
+			continue
+		}
+
+		if err != nil {
+			t.Errorf("validate returned err: %v", err)
+		}
+	}
+}


### PR DESCRIPTION
* Added a new `go-vela/cli/internal/client` pkg
* Added constants for the flag keys (`addr` and `token`) we parse for the client
* Added a `Parse()` function to `go-vela/cli/internal/client`
* Added tests for the `Parse()` function
* Added a `validate()` function to `go-vela/cli/internal/client`
* Added tests for the `validate()` function