### PR TITLE
refactor: use client.Parse in commands

### DIFF
--- a/action/build_get.go
+++ b/action/build_get.go
@@ -8,8 +8,7 @@ import (
 	"fmt"
 
 	"github.com/go-vela/cli/action/build"
-
-	"github.com/go-vela/sdk-go/vela"
+	"github.com/go-vela/cli/internal/client"
 
 	"github.com/urfave/cli/v2"
 )
@@ -87,14 +86,11 @@ DOCUMENTATION:
 // input and create the object used to
 // capture a list of builds.
 func buildGet(c *cli.Context) error {
-	// create a vela client
-	client, err := vela.NewClient(c.String("addr"), nil)
+	// parse the Vela client from the context
+	client, err := client.Parse(c)
 	if err != nil {
 		return err
 	}
-
-	// set token from global config
-	client.Authentication.SetTokenAuth(c.String("token"))
 
 	// create the build configuration
 	b := &build.Config{

--- a/action/build_restart.go
+++ b/action/build_restart.go
@@ -8,8 +8,7 @@ import (
 	"fmt"
 
 	"github.com/go-vela/cli/action/build"
-
-	"github.com/go-vela/sdk-go/vela"
+	"github.com/go-vela/cli/internal/client"
 
 	"github.com/urfave/cli/v2"
 )
@@ -72,14 +71,11 @@ DOCUMENTATION:
 // input and create the object used to
 // restart a build.
 func buildRestart(c *cli.Context) error {
-	// create a vela client
-	client, err := vela.NewClient(c.String("addr"), nil)
+	// parse the Vela client from the context
+	client, err := client.Parse(c)
 	if err != nil {
 		return err
 	}
-
-	// set token from global config
-	client.Authentication.SetTokenAuth(c.String("token"))
 
 	// create the build configuration
 	b := &build.Config{

--- a/action/build_view.go
+++ b/action/build_view.go
@@ -8,8 +8,7 @@ import (
 	"fmt"
 
 	"github.com/go-vela/cli/action/build"
-
-	"github.com/go-vela/sdk-go/vela"
+	"github.com/go-vela/cli/internal/client"
 
 	"github.com/urfave/cli/v2"
 )
@@ -74,14 +73,11 @@ DOCUMENTATION:
 // input and create the object used to
 // inspect a build.
 func buildView(c *cli.Context) error {
-	// create a vela client
-	client, err := vela.NewClient(c.String("addr"), nil)
+	// parse the Vela client from the context
+	client, err := client.Parse(c)
 	if err != nil {
 		return err
 	}
-
-	// set token from global config
-	client.Authentication.SetTokenAuth(c.String("token"))
 
 	// create the build configuration
 	b := &build.Config{

--- a/action/deployment_add.go
+++ b/action/deployment_add.go
@@ -8,8 +8,7 @@ import (
 	"fmt"
 
 	"github.com/go-vela/cli/action/deployment"
-
-	"github.com/go-vela/sdk-go/vela"
+	"github.com/go-vela/cli/internal/client"
 
 	"github.com/urfave/cli/v2"
 )
@@ -99,14 +98,11 @@ DOCUMENTATION:
 // input and create the object used to
 // create a deployment.
 func deploymentAdd(c *cli.Context) error {
-	// create a vela client
-	client, err := vela.NewClient(c.String("addr"), nil)
+	// parse the Vela client from the context
+	client, err := client.Parse(c)
 	if err != nil {
 		return err
 	}
-
-	// set token from global config
-	client.Authentication.SetTokenAuth(c.String("token"))
 
 	// create the deployment configuration
 	d := &deployment.Config{

--- a/action/deployment_get.go
+++ b/action/deployment_get.go
@@ -8,8 +8,7 @@ import (
 	"fmt"
 
 	"github.com/go-vela/cli/action/deployment"
-
-	"github.com/go-vela/sdk-go/vela"
+	"github.com/go-vela/cli/internal/client"
 
 	"github.com/urfave/cli/v2"
 )
@@ -87,14 +86,11 @@ DOCUMENTATION:
 // input and create the object used to
 // capture a list of deployments.
 func deploymentGet(c *cli.Context) error {
-	// create a vela client
-	client, err := vela.NewClient(c.String("addr"), nil)
+	// parse the Vela client from the context
+	client, err := client.Parse(c)
 	if err != nil {
 		return err
 	}
-
-	// set token from global config
-	client.Authentication.SetTokenAuth(c.String("token"))
 
 	// create the deployment configuration
 	d := &deployment.Config{

--- a/action/deployment_view.go
+++ b/action/deployment_view.go
@@ -8,8 +8,7 @@ import (
 	"fmt"
 
 	"github.com/go-vela/cli/action/deployment"
-
-	"github.com/go-vela/sdk-go/vela"
+	"github.com/go-vela/cli/internal/client"
 
 	"github.com/urfave/cli/v2"
 )
@@ -74,14 +73,11 @@ DOCUMENTATION:
 // input and create the object used to
 // inspect a deployment.
 func deploymentView(c *cli.Context) error {
-	// create a vela client
-	client, err := vela.NewClient(c.String("addr"), nil)
+	// parse the Vela client from the context
+	client, err := client.Parse(c)
 	if err != nil {
 		return err
 	}
-
-	// set token from global config
-	client.Authentication.SetTokenAuth(c.String("token"))
 
 	// create the deployment configuration
 	d := &deployment.Config{

--- a/action/hook_get.go
+++ b/action/hook_get.go
@@ -8,8 +8,7 @@ import (
 	"fmt"
 
 	"github.com/go-vela/cli/action/hook"
-
-	"github.com/go-vela/sdk-go/vela"
+	"github.com/go-vela/cli/internal/client"
 
 	"github.com/urfave/cli/v2"
 )
@@ -87,14 +86,11 @@ DOCUMENTATION:
 // input and create the object used to
 // capture a list of hooks.
 func hookGet(c *cli.Context) error {
-	// create a vela client
-	client, err := vela.NewClient(c.String("addr"), nil)
+	// parse the Vela client from the context
+	client, err := client.Parse(c)
 	if err != nil {
 		return err
 	}
-
-	// set token from global config
-	client.Authentication.SetTokenAuth(c.String("token"))
 
 	// create the hook configuration
 	h := &hook.Config{

--- a/action/hook_view.go
+++ b/action/hook_view.go
@@ -8,8 +8,7 @@ import (
 	"fmt"
 
 	"github.com/go-vela/cli/action/hook"
-
-	"github.com/go-vela/sdk-go/vela"
+	"github.com/go-vela/cli/internal/client"
 
 	"github.com/urfave/cli/v2"
 )
@@ -74,14 +73,11 @@ DOCUMENTATION:
 // input and create the object used to
 // inspect a hook.
 func hookView(c *cli.Context) error {
-	// create a vela client
-	client, err := vela.NewClient(c.String("addr"), nil)
+	// parse the Vela client from the context
+	client, err := client.Parse(c)
 	if err != nil {
 		return err
 	}
-
-	// set token from global config
-	client.Authentication.SetTokenAuth(c.String("token"))
 
 	// create the hook configuration
 	h := &hook.Config{

--- a/action/log_get.go
+++ b/action/log_get.go
@@ -8,8 +8,7 @@ import (
 	"fmt"
 
 	"github.com/go-vela/cli/action/log"
-
-	"github.com/go-vela/sdk-go/vela"
+	"github.com/go-vela/cli/internal/client"
 
 	"github.com/urfave/cli/v2"
 )
@@ -77,14 +76,11 @@ DOCUMENTATION:
 // input and create the object used to
 // capture a list of build logs.
 func logGet(c *cli.Context) error {
-	// create a vela client
-	client, err := vela.NewClient(c.String("addr"), nil)
+	// parse the Vela client from the context
+	client, err := client.Parse(c)
 	if err != nil {
 		return err
 	}
-
-	// set token from global config
-	client.Authentication.SetTokenAuth(c.String("token"))
 
 	// create the log configuration
 	s := &log.Config{

--- a/action/log_view.go
+++ b/action/log_view.go
@@ -8,8 +8,7 @@ import (
 	"fmt"
 
 	"github.com/go-vela/cli/action/log"
-
-	"github.com/go-vela/sdk-go/vela"
+	"github.com/go-vela/cli/internal/client"
 
 	"github.com/urfave/cli/v2"
 )
@@ -96,14 +95,11 @@ DOCUMENTATION:
 // input and create the object used to
 // inspect a log.
 func logView(c *cli.Context) error {
-	// create a vela client
-	client, err := vela.NewClient(c.String("addr"), nil)
+	// parse the Vela client from the context
+	client, err := client.Parse(c)
 	if err != nil {
 		return err
 	}
-
-	// set token from global config
-	client.Authentication.SetTokenAuth(c.String("token"))
 
 	// create the log configuration
 	l := &log.Config{

--- a/action/repo_add.go
+++ b/action/repo_add.go
@@ -8,8 +8,7 @@ import (
 	"fmt"
 
 	"github.com/go-vela/cli/action/repo"
-
-	"github.com/go-vela/sdk-go/vela"
+	"github.com/go-vela/cli/internal/client"
 
 	"github.com/go-vela/types/constants"
 
@@ -130,14 +129,11 @@ DOCUMENTATION:
 // input and create the object used to
 // create a repo.
 func repoAdd(c *cli.Context) error {
-	// create a vela client
-	client, err := vela.NewClient(c.String("addr"), nil)
+	// parse the Vela client from the context
+	client, err := client.Parse(c)
 	if err != nil {
 		return err
 	}
-
-	// set token from global config
-	client.Authentication.SetTokenAuth(c.String("token"))
 
 	// create the repo configuration
 	r := &repo.Config{

--- a/action/repo_chown.go
+++ b/action/repo_chown.go
@@ -8,8 +8,7 @@ import (
 	"fmt"
 
 	"github.com/go-vela/cli/action/repo"
-
-	"github.com/go-vela/sdk-go/vela"
+	"github.com/go-vela/cli/internal/client"
 
 	"github.com/urfave/cli/v2"
 )
@@ -65,14 +64,11 @@ DOCUMENTATION:
 // input and create the object used to
 // change ownership of a repository.
 func repoChown(c *cli.Context) error {
-	// create a vela client
-	client, err := vela.NewClient(c.String("addr"), nil)
+	// parse the Vela client from the context
+	client, err := client.Parse(c)
 	if err != nil {
 		return err
 	}
-
-	// set token from global config
-	client.Authentication.SetTokenAuth(c.String("token"))
 
 	// create the repo configuration
 	r := &repo.Config{

--- a/action/repo_get.go
+++ b/action/repo_get.go
@@ -8,8 +8,7 @@ import (
 	"fmt"
 
 	"github.com/go-vela/cli/action/repo"
-
-	"github.com/go-vela/sdk-go/vela"
+	"github.com/go-vela/cli/internal/client"
 
 	"github.com/urfave/cli/v2"
 )
@@ -70,14 +69,11 @@ DOCUMENTATION:
 // input and create the object used to
 // capture a list of repos.
 func repoGet(c *cli.Context) error {
-	// create a vela client
-	client, err := vela.NewClient(c.String("addr"), nil)
+	// parse the Vela client from the context
+	client, err := client.Parse(c)
 	if err != nil {
 		return err
 	}
-
-	// set token from global config
-	client.Authentication.SetTokenAuth(c.String("token"))
 
 	// create the repo configuration
 	r := &repo.Config{

--- a/action/repo_remove.go
+++ b/action/repo_remove.go
@@ -8,8 +8,7 @@ import (
 	"fmt"
 
 	"github.com/go-vela/cli/action/repo"
-
-	"github.com/go-vela/sdk-go/vela"
+	"github.com/go-vela/cli/internal/client"
 
 	"github.com/urfave/cli/v2"
 )
@@ -65,14 +64,11 @@ DOCUMENTATION:
 // input and create the object used to
 // remove a repository.
 func repoRemove(c *cli.Context) error {
-	// create a vela client
-	client, err := vela.NewClient(c.String("addr"), nil)
+	// parse the Vela client from the context
+	client, err := client.Parse(c)
 	if err != nil {
 		return err
 	}
-
-	// set token from global config
-	client.Authentication.SetTokenAuth(c.String("token"))
 
 	// create the repo configuration
 	r := &repo.Config{

--- a/action/repo_repair.go
+++ b/action/repo_repair.go
@@ -8,8 +8,7 @@ import (
 	"fmt"
 
 	"github.com/go-vela/cli/action/repo"
-
-	"github.com/go-vela/sdk-go/vela"
+	"github.com/go-vela/cli/internal/client"
 
 	"github.com/urfave/cli/v2"
 )
@@ -65,14 +64,11 @@ DOCUMENTATION:
 // input and create the object used to
 // repair settings of a repository.
 func repoRepair(c *cli.Context) error {
-	// create a vela client
-	client, err := vela.NewClient(c.String("addr"), nil)
+	// parse the Vela client from the context
+	client, err := client.Parse(c)
 	if err != nil {
 		return err
 	}
-
-	// set token from global config
-	client.Authentication.SetTokenAuth(c.String("token"))
 
 	// create the repo configuration
 	r := &repo.Config{

--- a/action/repo_update.go
+++ b/action/repo_update.go
@@ -8,8 +8,7 @@ import (
 	"fmt"
 
 	"github.com/go-vela/cli/action/repo"
-
-	"github.com/go-vela/sdk-go/vela"
+	"github.com/go-vela/cli/internal/client"
 
 	"github.com/go-vela/types/constants"
 
@@ -130,14 +129,11 @@ DOCUMENTATION:
 // input and create the object used to
 // modify a repository.
 func repoUpdate(c *cli.Context) error {
-	// create a vela client
-	client, err := vela.NewClient(c.String("addr"), nil)
+	// parse the Vela client from the context
+	client, err := client.Parse(c)
 	if err != nil {
 		return err
 	}
-
-	// set token from global config
-	client.Authentication.SetTokenAuth(c.String("token"))
 
 	// create the repo configuration
 	r := &repo.Config{

--- a/action/repo_view.go
+++ b/action/repo_view.go
@@ -8,8 +8,7 @@ import (
 	"fmt"
 
 	"github.com/go-vela/cli/action/repo"
-
-	"github.com/go-vela/sdk-go/vela"
+	"github.com/go-vela/cli/internal/client"
 
 	"github.com/urfave/cli/v2"
 )
@@ -65,14 +64,11 @@ DOCUMENTATION:
 // input and create the object used to
 // inspect a repository.
 func repoView(c *cli.Context) error {
-	// create a vela client
-	client, err := vela.NewClient(c.String("addr"), nil)
+	// parse the Vela client from the context
+	client, err := client.Parse(c)
 	if err != nil {
 		return err
 	}
-
-	// set token from global config
-	client.Authentication.SetTokenAuth(c.String("token"))
 
 	// create the repo configuration
 	r := &repo.Config{

--- a/action/secret_add.go
+++ b/action/secret_add.go
@@ -8,8 +8,7 @@ import (
 	"fmt"
 
 	"github.com/go-vela/cli/action/secret"
-
-	"github.com/go-vela/sdk-go/vela"
+	"github.com/go-vela/cli/internal/client"
 
 	"github.com/go-vela/types/constants"
 
@@ -144,14 +143,11 @@ DOCUMENTATION:
 // input and create the object used to
 // create a secret.
 func secretAdd(c *cli.Context) error {
-	// create a vela client
-	client, err := vela.NewClient(c.String("addr"), nil)
+	// parse the Vela client from the context
+	client, err := client.Parse(c)
 	if err != nil {
 		return err
 	}
-
-	// set token from global config
-	client.Authentication.SetTokenAuth(c.String("token"))
 
 	// create the secret configuration
 	s := &secret.Config{

--- a/action/secret_get.go
+++ b/action/secret_get.go
@@ -8,8 +8,7 @@ import (
 	"fmt"
 
 	"github.com/go-vela/cli/action/secret"
-
-	"github.com/go-vela/sdk-go/vela"
+	"github.com/go-vela/cli/internal/client"
 
 	"github.com/go-vela/types/constants"
 
@@ -111,8 +110,8 @@ DOCUMENTATION:
 // input and create the object used to
 // capture a list of secrets.
 func secretGet(c *cli.Context) error {
-	// create a vela client
-	client, err := vela.NewClient(c.String("addr"), nil)
+	// parse the Vela client from the context
+	client, err := client.Parse(c)
 	if err != nil {
 		return err
 	}

--- a/action/secret_remove.go
+++ b/action/secret_remove.go
@@ -8,8 +8,7 @@ import (
 	"fmt"
 
 	"github.com/go-vela/cli/action/secret"
-
-	"github.com/go-vela/sdk-go/vela"
+	"github.com/go-vela/cli/internal/client"
 
 	"github.com/go-vela/types/constants"
 
@@ -100,14 +99,11 @@ DOCUMENTATION:
 // input and create the object used to
 // remove a secret.
 func secretRemove(c *cli.Context) error {
-	// create a vela client
-	client, err := vela.NewClient(c.String("addr"), nil)
+	// parse the Vela client from the context
+	client, err := client.Parse(c)
 	if err != nil {
 		return err
 	}
-
-	// set token from global config
-	client.Authentication.SetTokenAuth(c.String("token"))
 
 	// create the secret configuration
 	s := &secret.Config{

--- a/action/secret_update.go
+++ b/action/secret_update.go
@@ -8,8 +8,7 @@ import (
 	"fmt"
 
 	"github.com/go-vela/cli/action/secret"
-
-	"github.com/go-vela/sdk-go/vela"
+	"github.com/go-vela/cli/internal/client"
 
 	"github.com/go-vela/types/constants"
 
@@ -144,14 +143,11 @@ DOCUMENTATION:
 // input and create the object used to
 // modify a secret.
 func secretUpdate(c *cli.Context) error {
-	// create a vela client
-	client, err := vela.NewClient(c.String("addr"), nil)
+	// parse the Vela client from the context
+	client, err := client.Parse(c)
 	if err != nil {
 		return err
 	}
-
-	// set token from global config
-	client.Authentication.SetTokenAuth(c.String("token"))
 
 	// create the secret configuration
 	s := &secret.Config{

--- a/action/secret_view.go
+++ b/action/secret_view.go
@@ -8,8 +8,7 @@ import (
 	"fmt"
 
 	"github.com/go-vela/cli/action/secret"
-
-	"github.com/go-vela/sdk-go/vela"
+	"github.com/go-vela/cli/internal/client"
 
 	"github.com/go-vela/types/constants"
 
@@ -100,14 +99,11 @@ DOCUMENTATION:
 // input and create the object used to
 // inspect a secret.
 func secretView(c *cli.Context) error {
-	// create a vela client
-	client, err := vela.NewClient(c.String("addr"), nil)
+	// parse the Vela client from the context
+	client, err := client.Parse(c)
 	if err != nil {
 		return err
 	}
-
-	// set token from global config
-	client.Authentication.SetTokenAuth(c.String("token"))
 
 	// create the secret configuration
 	s := &secret.Config{

--- a/action/service_get.go
+++ b/action/service_get.go
@@ -8,8 +8,7 @@ import (
 	"fmt"
 
 	"github.com/go-vela/cli/action/service"
-
-	"github.com/go-vela/sdk-go/vela"
+	"github.com/go-vela/cli/internal/client"
 
 	"github.com/urfave/cli/v2"
 )
@@ -96,14 +95,11 @@ DOCUMENTATION:
 // input and create the object used to
 // capture a list of services.
 func serviceGet(c *cli.Context) error {
-	// create a vela client
-	client, err := vela.NewClient(c.String("addr"), nil)
+	// parse the Vela client from the context
+	client, err := client.Parse(c)
 	if err != nil {
 		return err
 	}
-
-	// set token from global config
-	client.Authentication.SetTokenAuth(c.String("token"))
 
 	// create the service configuration
 	s := &service.Config{

--- a/action/service_view.go
+++ b/action/service_view.go
@@ -8,8 +8,7 @@ import (
 	"fmt"
 
 	"github.com/go-vela/cli/action/service"
-
-	"github.com/go-vela/sdk-go/vela"
+	"github.com/go-vela/cli/internal/client"
 
 	"github.com/urfave/cli/v2"
 )
@@ -83,14 +82,11 @@ DOCUMENTATION:
 // input and create the object used to
 // inspect a service.
 func serviceView(c *cli.Context) error {
-	// create a vela client
-	client, err := vela.NewClient(c.String("addr"), nil)
+	// parse the Vela client from the context
+	client, err := client.Parse(c)
 	if err != nil {
 		return err
 	}
-
-	// set token from global config
-	client.Authentication.SetTokenAuth(c.String("token"))
 
 	// create the service configuration
 	s := &service.Config{

--- a/action/step_get.go
+++ b/action/step_get.go
@@ -8,8 +8,7 @@ import (
 	"fmt"
 
 	"github.com/go-vela/cli/action/step"
-
-	"github.com/go-vela/sdk-go/vela"
+	"github.com/go-vela/cli/internal/client"
 
 	"github.com/urfave/cli/v2"
 )
@@ -96,14 +95,11 @@ DOCUMENTATION:
 // input and create the object used to
 // capture a list of steps.
 func stepGet(c *cli.Context) error {
-	// create a vela client
-	client, err := vela.NewClient(c.String("addr"), nil)
+	// parse the Vela client from the context
+	client, err := client.Parse(c)
 	if err != nil {
 		return err
 	}
-
-	// set token from global config
-	client.Authentication.SetTokenAuth(c.String("token"))
 
 	// create the step configuration
 	s := &step.Config{

--- a/action/step_view.go
+++ b/action/step_view.go
@@ -8,8 +8,7 @@ import (
 	"fmt"
 
 	"github.com/go-vela/cli/action/step"
-
-	"github.com/go-vela/sdk-go/vela"
+	"github.com/go-vela/cli/internal/client"
 
 	"github.com/urfave/cli/v2"
 )
@@ -83,14 +82,11 @@ DOCUMENTATION:
 // input and create the object used to
 // inspect a step.
 func stepView(c *cli.Context) error {
-	// create a vela client
-	client, err := vela.NewClient(c.String("addr"), nil)
+	// parse the Vela client from the context
+	client, err := client.Parse(c)
 	if err != nil {
 		return err
 	}
-
-	// set token from global config
-	client.Authentication.SetTokenAuth(c.String("token"))
 
 	// create the step configuration
 	s := &step.Config{


### PR DESCRIPTION
* Update all `go-vela/cli/action/*` command files to use `go-vela/cli/internal/client.Parse()` function