### PR TITLE
feat: add completion action and commands

### DIFF
--- a/action/completion/bash.go
+++ b/action/completion/bash.go
@@ -1,0 +1,29 @@
+// Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+//
+// Use of this source code is governed by the LICENSE file in this repository.
+
+package completion
+
+// BashAutoComplete represents the script used
+// to enable automatic completion for the
+// Bash (https://www.gnu.org/software/bash/) Unix shell.
+const BashAutoComplete = `#! /bin/bash
+  _cli_bash_autocomplete() {
+    if [[ "${COMP_WORDS[0]}" != "source" ]]; then
+      local cur opts base
+      COMPREPLY=()
+      cur="${COMP_WORDS[COMP_CWORD]}"
+
+      if [[ "$cur" == "-"* ]]; then
+        opts=$( ${COMP_WORDS[@]:0:$COMP_CWORD} ${cur} --generate-bash-completion )
+      else
+        opts=$( ${COMP_WORDS[@]:0:$COMP_CWORD} --generate-bash-completion )
+      fi
+
+      COMPREPLY=( $(compgen -W "${opts}" -- ${cur}) )
+        return 0
+    fi
+  }
+
+  complete -o bashdefault -o default -o nospace -F _cli_bash_autocomplete vela
+`

--- a/action/completion/completion.go
+++ b/action/completion/completion.go
@@ -1,0 +1,13 @@
+// Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+//
+// Use of this source code is governed by the LICENSE file in this repository.
+
+package completion
+
+// Config represents the configuration necessary
+// to perform completion related requests with Vela.
+type Config struct {
+	Action string
+	Bash   bool
+	Zsh    bool
+}

--- a/action/completion/doc.go
+++ b/action/completion/doc.go
@@ -1,0 +1,10 @@
+// Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+//
+// Use of this source code is governed by the LICENSE file in this repository.
+
+// Package completion provides the defined CLI completion actions for Vela.
+//
+// Usage:
+//
+// 	import "github.com/go-vela/cli/action/completion"
+package completion

--- a/action/completion/generate.go
+++ b/action/completion/generate.go
@@ -1,0 +1,33 @@
+// Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+//
+// Use of this source code is governed by the LICENSE file in this repository.
+
+package completion
+
+import (
+	"fmt"
+
+	"github.com/go-vela/cli/internal/output"
+)
+
+// Generate produces a script used to enable
+// automatic completion for a Unix shell
+// based off the provided configuration.
+func (c *Config) Generate() error {
+	// generate the script based off the provided configuration
+	switch {
+	case c.Bash:
+		// output the bash auto completion in stdout format
+		//
+		// https://pkg.go.dev/github.com/go-vela/cli/internal/output?tab=doc#Stdout
+		return output.Stdout(BashAutoComplete)
+	case c.Zsh:
+		// output the zsh auto completion in stdout format
+		//
+		// https://pkg.go.dev/github.com/go-vela/cli/internal/output?tab=doc#Stdout
+		return output.Stdout(ZshAutoComplete)
+	default:
+		// produce an invalid shell error by default
+		return fmt.Errorf("invalid shell provided for completion")
+	}
+}

--- a/action/completion/generate_test.go
+++ b/action/completion/generate_test.go
@@ -1,0 +1,55 @@
+// Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+//
+// Use of this source code is governed by the LICENSE file in this repository.
+
+package completion
+
+import (
+	"testing"
+)
+
+func TestCompletion_Config_Generate(t *testing.T) {
+	// setup tests
+	tests := []struct {
+		failure bool
+		config  *Config
+	}{
+		{
+			failure: false,
+			config: &Config{
+				Action: "generate",
+				Bash:   true,
+			},
+		},
+		{
+			failure: false,
+			config: &Config{
+				Action: "generate",
+				Zsh:    true,
+			},
+		},
+		{
+			failure: true,
+			config: &Config{
+				Action: "generate",
+			},
+		},
+	}
+
+	// run tests
+	for _, test := range tests {
+		err := test.config.Generate()
+
+		if test.failure {
+			if err == nil {
+				t.Errorf("Generate should have returned err")
+			}
+
+			continue
+		}
+
+		if err != nil {
+			t.Errorf("Generate returned err: %v", err)
+		}
+	}
+}

--- a/action/completion/validate.go
+++ b/action/completion/validate.go
@@ -1,0 +1,24 @@
+// Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+//
+// Use of this source code is governed by the LICENSE file in this repository.
+
+package completion
+
+import (
+	"fmt"
+)
+
+// Validate verifies the configuration provided.
+func (c *Config) Validate() error {
+	// check if multiple shells are set
+	if c.Bash && c.Zsh {
+		return fmt.Errorf("multiple shells provided for completion")
+	}
+
+	// check if no shell is set
+	if !c.Bash && !c.Zsh {
+		return fmt.Errorf("no shell provided for completion")
+	}
+
+	return nil
+}

--- a/action/completion/validate_test.go
+++ b/action/completion/validate_test.go
@@ -1,0 +1,63 @@
+// Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+//
+// Use of this source code is governed by the LICENSE file in this repository.
+
+package completion
+
+import (
+	"testing"
+)
+
+func TestCompletion_Config_Validate(t *testing.T) {
+	// setup tests
+	tests := []struct {
+		failure bool
+		config  *Config
+	}{
+		{
+			failure: false,
+			config: &Config{
+				Action: "generate",
+				Bash:   true,
+			},
+		},
+		{
+			failure: false,
+			config: &Config{
+				Action: "generate",
+				Zsh:    true,
+			},
+		},
+		{
+			failure: true,
+			config: &Config{
+				Action: "generate",
+				Bash:   true,
+				Zsh:    true,
+			},
+		},
+		{
+			failure: true,
+			config: &Config{
+				Action: "generate",
+			},
+		},
+	}
+
+	// run tests
+	for _, test := range tests {
+		err := test.config.Validate()
+
+		if test.failure {
+			if err == nil {
+				t.Errorf("Validate should have returned err")
+			}
+
+			continue
+		}
+
+		if err != nil {
+			t.Errorf("Validate returned err: %v", err)
+		}
+	}
+}

--- a/action/completion/zsh.go
+++ b/action/completion/zsh.go
@@ -1,0 +1,31 @@
+// Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+//
+// Use of this source code is governed by the LICENSE file in this repository.
+
+package completion
+
+// ZshAutoComplete represents the script used
+// to enable automatic completion for the
+// Zsh (https://ohmyz.sh/) Unix shell.
+const ZshAutoComplete = `#comdef vela
+  _cli_zsh_autocomplete() {
+    local -a opts
+    local cur
+    cur=${words[-1]}
+
+    if [[ "$cur" == "-"* ]]; then
+      opts=("${(@f)$(_CLI_ZSH_AUTOCOMPLETE_HACK=1 ${words[@]:0:#words[@]-1} ${cur} --generate-bash-completion)}")
+    else
+      opts=("${(@f)$(_CLI_ZSH_AUTOCOMPLETE_HACK=1 ${words[@]:0:#words[@]-1} --generate-bash-completion)}")
+    fi
+
+    if [[ "${opts[1]}" != "" ]]; then
+      _describe 'values' opts
+    fi
+
+    return
+  }
+
+  export _CLI_ZSH_AUTOCOMPLETE_HACK=1
+  compdef _cli_zsh_autocomplete vela
+`

--- a/action/completion_generate.go
+++ b/action/completion_generate.go
@@ -1,0 +1,80 @@
+// Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+//
+// Use of this source code is governed by the LICENSE file in this repository.
+
+package action
+
+import (
+	"fmt"
+
+	"github.com/go-vela/cli/action/completion"
+
+	"github.com/urfave/cli/v2"
+)
+
+// CompletionGenerate defines the command for producing an auto completion script.
+var CompletionGenerate = &cli.Command{
+	Name:        "completion",
+	Description: "Use this command to generate a shell auto completion script.",
+	Usage:       "Generate a shell auto completion script",
+	Action:      completionGenerate,
+	Flags: []cli.Flag{
+
+		// Shell Flags
+
+		&cli.BoolFlag{
+			EnvVars: []string{"VELA_BASH", "COMPLETION_BASH"},
+			Name:    "bash",
+			Aliases: []string{"b"},
+			Usage:   "generate a bash auto completion script",
+		},
+		&cli.BoolFlag{
+			EnvVars: []string{"VELA_ZSH", "COMPLETION_ZSH"},
+			Name:    "zsh",
+			Aliases: []string{"z"},
+			Usage:   "generate a zsh auto completion script",
+		},
+	},
+	CustomHelpTemplate: fmt.Sprintf(`%s
+EXAMPLES:
+  1. Enable auto completion for the current bash session.
+    $ source <({{.HelpName}} --bash)
+  2. Enable auto completion for the current zsh session.
+    $ source <({{.HelpName}} --zsh)
+  3. Enable auto completion for bash permanently.
+    visit https://go-vela.github.io/docs/cli/completion/generate/#bash
+  4. Enable auto completion for zsh permanently.
+    visit https://go-vela.github.io/docs/cli/completion/generate/#zsh
+
+DOCUMENTATION:
+
+  https://go-vela.github.io/docs/cli/completion/generate/
+`, cli.CommandHelpTemplate),
+}
+
+// helper function to capture the provided
+// input and create the object used to
+// produce the config file.
+func completionGenerate(c *cli.Context) error {
+	// create the completion configuration
+	//
+	// https://pkg.go.dev/github.com/go-vela/cli/action/completion?tab=doc#Config
+	comp := &completion.Config{
+		Action: generateAction,
+		Bash:   c.Bool("bash"),
+		Zsh:    c.Bool("zsh"),
+	}
+
+	// validate completion configuration
+	//
+	// https://pkg.go.dev/github.com/go-vela/cli/action/completion?tab=doc#Config.Validate
+	err := comp.Validate()
+	if err != nil {
+		return err
+	}
+
+	// execute the generate call for the completion configuration
+	//
+	// https://pkg.go.dev/github.com/go-vela/cli/action/completion?tab=doc#Config.Generate
+	return comp.Generate()
+}

--- a/action/completion_generate_test.go
+++ b/action/completion_generate_test.go
@@ -1,0 +1,57 @@
+// Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+//
+// Use of this source code is governed by the LICENSE file in this repository.
+
+package action
+
+import (
+	"flag"
+	"testing"
+
+	"github.com/urfave/cli/v2"
+)
+
+func TestAction_CompletionGenerate(t *testing.T) {
+	// setup flags
+	bashSet := flag.NewFlagSet("test", 0)
+	bashSet.Bool("bash", true, "doc")
+
+	zshSet := flag.NewFlagSet("test", 0)
+	zshSet.Bool("zsh", true, "doc")
+
+	// setup tests
+	tests := []struct {
+		failure bool
+		set     *flag.FlagSet
+	}{
+		{
+			failure: false,
+			set:     bashSet,
+		},
+		{
+			failure: false,
+			set:     zshSet,
+		},
+		{
+			failure: true,
+			set:     flag.NewFlagSet("test", 0),
+		},
+	}
+
+	// run tests
+	for _, test := range tests {
+		err := completionGenerate(cli.NewContext(nil, test.set, nil))
+
+		if test.failure {
+			if err == nil {
+				t.Errorf("completionGenerate should have returned err")
+			}
+
+			continue
+		}
+
+		if err != nil {
+			t.Errorf("completionGenerate returned err: %v", err)
+		}
+	}
+}


### PR DESCRIPTION
* Added a new `go-vela/cli/action/completion` pkg
* Created a `BashAutoComplete` constant for the auto completion script
* Created a `ZshAutoComplete` constant for the auto completion script
* Added a `Generate()` function to `go-vela/cli/action/completion`
* Added tests for the `Generate()` function
* Added a `Validate()` function to `go-vela/cli/action/completion`
* Added tests for the `Validate()` function
* Added a `CompletionGenerate` command to `go-vela/cli/action`
* Added a `completionGenerate()` function called by `CompletionGenerate` command
* Added tests for the `completionGenerate()` function

