### PR TITLE
ci: refactor Makefile. improve linter setup. upgrade deps.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
       image: golang:latest
     steps:
     - name: clone
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
 
     - name: build
       run: |

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -21,7 +21,7 @@ jobs:
       image: golang:latest
     steps:
     - name: clone
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
 
     - name: build
       uses: skx/github-action-build@master

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,7 +14,7 @@ jobs:
       image: golang:latest
     steps:
     - name: clone
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
 
     - name: build
       uses: skx/github-action-build@master

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
       image: golang:latest
     steps:
       - name: clone
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
 
       - name: tags
         run: |

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -13,7 +13,7 @@ jobs:
       image: golang:latest
     steps:
     - name: clone
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
 
     - name: golangci-lint
       uses: reviewdog/action-golangci-lint@v1
@@ -30,7 +30,7 @@ jobs:
       image: golang:latest
     steps:
     - name: clone
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
 
     - name: golangci-lint
       uses: reviewdog/action-golangci-lint@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
       image: golang:latest
     steps:
     - name: clone
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
 
     - name: install
       run: |

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -14,7 +14,7 @@ jobs:
       image: golang:latest
     steps:
     - name: clone
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
 
     - name: validate
       run: |

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -24,3 +24,5 @@ jobs:
         go vet ./... && git diff --exit-code; code=$?; git checkout -- .; (exit $code)
         # Check that go fmt ./... produces a zero diff; clean up any changes afterwards.
         go fmt ./... && git diff --exit-code; code=$?; git checkout -- .; (exit $code)
+        # Check that go fix ./... produces a zero diff; clean up any changes afterwards.
+        go fix ./... && git diff --exit-code; code=$?; git checkout -- .; (exit $code)

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,14 +2,64 @@
 # some defaults explicitly provided. There is a large number of
 # linters we've enabled that are usually disabled by default.
 #
-# https://github.com/golangci/golangci-lint#config-file
+# https://golangci-lint.run/usage/configuration/#config-file
 
 # This section provides the configuration for how golangci
 # outputs it results from the linters it executes.
 output:
+  # colored-line-number|line-number|json|tab|checkstyle|code-climate, default is "colored-line-number"
   format: colored-line-number
+
+  # print lines of code with issue, default is true
   print-issued-lines: true
+
+  # print linter name in the end of issue text, default is true
   print-linter-name: true
+
+  # make issues output unique by line, default is true
+  uniq-by-line: true
+
+# This section provides the configuration for each linter
+# we've instructed golangci to execute.
+linters-settings:
+  # https://github.com/mibk/dupl
+  dupl:
+    threshold: 100
+
+  # https://github.com/ultraware/funlen
+  funlen:
+    lines: 100
+    statements: 50
+
+  # https://github.com/golang/lint
+  golint:
+    min-confidence: 0
+
+  # https://github.com/tommy-muehle/go-mnd
+  gomnd:
+    settings:
+      mnd:
+        # don't include the "operation" and "assign"
+        checks: argument,case,condition,return
+
+  # https://github.com/walle/lll
+  lll:
+    line-length: 100
+
+  # https://github.com/mdempsky/maligned
+  maligned:
+    suggest-new: true
+
+  # https://github.com/client9/misspell
+  misspell:
+    locale: US
+
+  # https://github.com/golangci/golangci-lint/blob/master/pkg/golinters/nolintlint
+  nolintlint:
+    allow-leading-space: true # don't require machine-readable nolint directives (i.e. with no leading space)
+    allow-unused: false # report any unused nolint directives
+    require-explanation: false # don't require an explanation for nolint directives
+    require-specific: false # don't require nolint directives to be specific about which linter is being skipped
 
 # This section provides the configuration for which linters
 # golangci will execute. Several of them were disabled by
@@ -17,57 +67,71 @@ output:
 linters:
   # disable all linters as new linters might be added to golangci
   disable-all: true
-  enable:
-    # linters enabled by default
-    - deadcode
-    - errcheck
-    - govet
-    - gosimple # a.k.a. megacheck
-    - ineffassign
-    - staticcheck
-    - structcheck
-    - typecheck
-    - unused
-    - varcheck
 
-    # linters disabled by default
+  # enable a specific set of linters to run
+  enable:
     - bodyclose
-    - gocognit
+    - deadcode # enabled by default
+    - dupl
+    - errcheck # enabled by default
+    - funlen
     - goconst
     - gocyclo
+    - godot
+    - gofmt
     - goimports
+    - golint
+    - gomnd
+    - goprintffuncname
     - gosec
-    - funlen
+    - gosimple # enabled by default
+    - govet # enabled by default
+    - ineffassign # enabled by default
+    - lll
     - maligned
     - misspell
+    - nakedret
+    - nolintlint
+    - staticcheck # enabled by default
+    - structcheck # enabled by default
     - stylecheck
+    - typecheck # enabled by default
+    - unconvert
     - unparam
+    - unused # enabled by default
+    - varcheck # enabled by default
     - whitespace
-    - wsl
 
   # static list of linters we know golangci can run but we've
   # chosen to leave disabled for now
-  #
-  # disable:
-  #   - depguard
-  #   - dogsled
-  #   - dupl
-  #   - gocritic
-  #   - gochecknoinits
-  #   - gochecknoglobals
-  #   - godox
-  #   - gofmt
-  #   - golint
-  #   - gomnd
-  #   - interfacer
-  #   - lll
-  #   - nakedret
-  #   - scopelint
-  #   - unconvert
+  # - asciicheck
+  # - depguard
+  # - dogsled
+  # - exhaustive
+  # - gochecknoinits
+  # - gochecknoglobals
+  # - gocognit
+  # - gocritic
+  # - godox
+  # - goerr113
+  # - interfacer
+  # - nestif
+  # - noctx
+  # - prealloc
+  # - rowserrcheck
+  # - scopelint
+  # - testpackage
+  # - wsl
 
-# This section provides the configuration for each linter
-# we've instructed golangci to execute.
-linters-settings:
-  funlen:
-    lines: 100
-    statements: 60
+# This section provides the configuration for how golangci
+# will report the issues it finds.
+issues:
+  # Excluding configuration per-path, per-linter, per-text and per-source
+  exclude-rules:
+    # prevent linters from running on *_test.go files
+    - path: _test\.go
+      linters:
+        - funlen
+        - goconst
+        - gocyclo
+        - gomnd

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@
 #
 # Use of this source code is governed by the LICENSE file in this repository.
 
+.PHONY: clean
 clean:
 	#################################
 	######      Go clean       ######
@@ -14,6 +15,7 @@ clean:
 	@go test ./...
 	@echo "I'm kind of the only name in clean energy right now"
 
+.PHONY: build
 build:
 	#################################
 	###### Build Golang Binary ######

--- a/Makefile
+++ b/Makefile
@@ -3,26 +3,254 @@
 #
 # Use of this source code is governed by the LICENSE file in this repository.
 
+# The `clean` target is intended to clean the workspace
+# and prepare the local changes for submission.
+#
+# Usage: `make clean`
 .PHONY: clean
-clean:
-	#################################
-	######      Go clean       ######
-	#################################
+clean: tidy vet fmt fix
 
-	@go mod tidy
-	@go vet ./...
-	@go fmt ./...
-	@go test ./...
-	@echo "I'm kind of the only name in clean energy right now"
-
+# The `build` target is intended to compile
+# the Go source code into a binary.
+#
+# Usage: `make build`
 .PHONY: build
-build:
-	#################################
-	###### Build Golang Binary ######
-	#################################
+build: build-darwin build-linux build-windows
 
-	GOOS=linux   CGO_ENABLED=0 GOARCH=amd64 go build -o release/linux/amd64/vela   github.com/go-vela/cli/cmd/vela-cli
-	GOOS=linux   CGO_ENABLED=0 GOARCH=arm64 go build -o release/linux/arm64/vela   github.com/go-vela/cli/cmd/vela-cli
-	GOOS=linux   CGO_ENABLED=0 GOARCH=arm   go build -o release/linux/arm/vela     github.com/go-vela/cli/cmd/vela-cli
-	GOOS=windows CGO_ENABLED=0 GOARCH=amd64 go build -o release/windows/amd64/vela github.com/go-vela/cli/cmd/vela-cli
-	GOOS=darwin  CGO_ENABLED=0 GOARCH=amd64 go build -o release/darwin/amd64/vela  github.com/go-vela/cli/cmd/vela-cli
+# The `build-static` target is intended to compile
+# the Go source code into a statically linked binary.
+#
+# Usage: `make build-static`
+.PHONY: build-static
+build-static: build-darwin-static build-linux-static build-windows-static
+
+# The `tidy` target is intended to clean up
+# the Go module files (go.mod & go.sum).
+#
+# Usage: `make tidy`
+.PHONY: tidy
+tidy:
+	@echo
+	@echo "### Tidying Go module"
+	@go mod tidy
+
+# The `vet` target is intended to inspect the
+# Go source code for potential issues.
+#
+# Usage: `make vet`
+.PHONY: vet
+vet:
+	@echo
+	@echo "### Vetting Go code"
+	@go vet ./...
+
+# The `fmt` target is intended to format the
+# Go source code to meet the language standards.
+#
+# Usage: `make fmt`
+.PHONY: fmt
+fmt:
+	@echo
+	@echo "### Formatting Go Code"
+	@go fmt ./...
+
+# The `fix` target is intended to rewrite the
+# Go source code using old APIs.
+#
+# Usage: `make fix`
+.PHONY: fix
+fix:
+	@echo
+	@echo "### Fixing Go Code"
+	@go fix ./...
+
+# The `test` target is intended to run
+# the tests for the Go source code.
+#
+# Usage: `make test`
+.PHONY: test
+test:
+	@echo
+	@echo "### Testing Go Code"
+	@go test -race ./...
+
+# The `test-cover` target is intended to run
+# the tests for the Go source code and then
+# open the test coverage report.
+#
+# Usage: `make test-cover`
+.PHONY: test-cover
+test-cover:
+	@echo
+	@echo "### Creating test coverage report"
+	@go test -race -covermode=atomic -coverprofile=coverage.out ./...
+	@echo
+	@echo "### Opening test coverage report"
+	@go tool cover -html=coverage.out
+
+# The `build-darwin` target is intended to compile the
+# Go source code into a Darwin compatible (MacOS) binary.
+#
+# Usage: `make build-darwin`
+.PHONY: build-darwin
+build-darwin:
+	@echo
+	@echo "### Building release/darwin/amd64/vela binary"
+	GOOS=darwin CGO_ENABLED=0 GOARCH=amd64 \
+		go build -a \
+		-o release/darwin/amd64/vela \
+		github.com/go-vela/cli/cmd/vela-cli
+
+# The `build-linux` target is intended to compile the
+# Go source code into a Linux compatible binary.
+#
+# Usage: `make build-linux`
+.PHONY: build-linux
+build-linux:
+	@echo
+	@echo "### Building release/linux/amd64/vela binary"
+	GOOS=linux CGO_ENABLED=0 GOARCH=amd64 \
+		go build -a \
+		-o release/linux/amd64/vela \
+		github.com/go-vela/cli/cmd/vela-cli
+	@echo
+	@echo "### Building release/linux/arm64/vela binary"
+	GOOS=linux CGO_ENABLED=0 GOARCH=arm64 \
+		go build -a \
+		-o release/linux/arm64/vela \
+		github.com/go-vela/cli/cmd/vela-cli
+	@echo
+	@echo "### Building release/linux/arm/vela binary"
+	GOOS=linux CGO_ENABLED=0 GOARCH=arm \
+		go build -a \
+		-o release/linux/arm/vela \
+		github.com/go-vela/cli/cmd/vela-cli
+
+# The `build-windows` target is intended to compile the
+# Go source code into a Windows compatible binary.
+#
+# Usage: `make build-windows`
+.PHONY: build-windows
+build-windows:
+	@echo
+	@echo "### Building release/windows/amd64/vela binary"
+	GOOS=windows CGO_ENABLED=0 GOARCH=amd64 \
+		go build -a \
+		-o release/windows/amd64/vela \
+		github.com/go-vela/cli/cmd/vela-cli
+
+# The `build-darwin-static` target is intended to compile the
+# Go source code into a statically linked, Darwin compatible (MacOS) binary.
+#
+# Usage: `make build-darwin-static`
+.PHONY: build-darwin-static
+build-darwin-static:
+	@echo
+	@echo "### Building release/darwin/amd64/vela binary"
+	GOOS=darwin CGO_ENABLED=0 GOARCH=amd64 \
+		go build -a \
+		-ldflags '-s -w -extldflags "-static"' \
+		-o release/darwin/amd64/vela \
+		github.com/go-vela/cli/cmd/vela-cli
+
+# The `build-linux-static` target is intended to compile the
+# Go source code into a statically linked, Linux compatible binary.
+#
+# Usage: `make build-linux-static`
+.PHONY: build-linux-static
+build-linux-static:
+	@echo
+	@echo "### Building release/linux/amd64/vela binary"
+	GOOS=linux CGO_ENABLED=0 GOARCH=amd64 \
+		go build -a \
+		-ldflags '-s -w -extldflags "-static"' \
+		-o release/linux/amd64/vela \
+		github.com/go-vela/cli/cmd/vela-cli
+	@echo
+	@echo "### Building release/linux/arm64/vela binary"
+	GOOS=linux CGO_ENABLED=0 GOARCH=arm64 \
+		go build -a \
+		-ldflags '-s -w -extldflags "-static"' \
+		-o release/linux/arm64/vela \
+		github.com/go-vela/cli/cmd/vela-cli
+	@echo
+	@echo "### Building release/linux/arm/vela binary"
+	GOOS=linux CGO_ENABLED=0 GOARCH=arm \
+		go build -a \
+		-ldflags '-s -w -extldflags "-static"' \
+		-o release/linux/arm/vela \
+		github.com/go-vela/cli/cmd/vela-cli
+
+# The `build-windows-static` target is intended to compile the
+# Go source code into a statically linked, Windows compatible binary.
+#
+# Usage: `make build-windows-static`
+.PHONY: build-windows-static
+build-windows-static:
+	@echo
+	@echo "### Building release/windows/amd64/vela binary"
+	GOOS=windows CGO_ENABLED=0 GOARCH=amd64 \
+		go build -a \
+		-ldflags '-s -w -extldflags "-static"' \
+		-o release/windows/amd64/vela \
+		github.com/go-vela/cli/cmd/vela-cli
+
+# The `check` target is intended to output all
+# dependencies from the Go module that need updates.
+#
+# Usage: `make check`
+.PHONY: check
+check: check-install
+	@echo
+	@echo "### Checking dependencies for updates"
+	@go list -u -m -json all | go-mod-outdated -update
+
+# The `check-direct` target is intended to output direct
+# dependencies from the Go module that need updates.
+#
+# Usage: `make check-direct`
+.PHONY: check-direct
+check-direct: check-install
+	@echo
+	@echo "### Checking direct dependencies for updates"
+	@go list -u -m -json all | go-mod-outdated -direct
+
+# The `check-full` target is intended to output
+# all dependencies from the Go module.
+#
+# Usage: `make check-full`
+.PHONY: check-full
+check-full: check-install
+	@echo
+	@echo "### Checking all dependencies for updates"
+	@go list -u -m -json all | go-mod-outdated
+
+# The `check-install` target is intended to download
+# the tool used to check dependencies from the Go module.
+#
+# Usage: `make check-install`
+.PHONY: check-install
+check-install:
+	@echo
+	@echo "### Installing psampaz/go-mod-outdated"
+	@go get -u github.com/psampaz/go-mod-outdated
+
+# The `bump-deps` target is intended to upgrade
+# non-test dependencies for the Go module.
+#
+# Usage: `make bump-deps`
+.PHONY: bump-deps
+bump-deps: check
+	@echo
+	@echo "### Upgrading dependencies"
+	@go get -u ./...
+
+# The `bump-deps-full` target is intended to upgrade
+# all dependencies for the Go module.
+#
+# Usage: `make bump-deps-full`
+.PHONY: bump-deps-full
+bump-deps-full: check
+	@echo
+	@echo "### Upgrading all dependencies"
+	@go get -t -u ./...

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
+
 # Copyright (c) 2020 Target Brands, Inc. All rights reserved.
 #
 # Use of this source code is governed by the LICENSE file in this repository.

--- a/codecov.yml
+++ b/codecov.yml
@@ -20,10 +20,17 @@ coverage:
   round: down
   range: "70...100"
 
+  # https://docs.codecov.io/docs/commit-status
   status:
-    project: yes
-    patch: yes
-    changes: no
+    # set rules for the project status report
+    project:
+      default:
+        target: 90%
+        threshold: 0%
+    # disable the patch status report
+    patch: off
+    # disable the changes status report
+    changes: off
 
 # This section provides the configuration for the
 # parsers codecov uses for the coverage report.


### PR DESCRIPTION
* Add `.PHONY` tags to Makefile
* Add new `make` targets for upgrading dependencies
* Skip the `patch` status from codecov.io
* Add more linters to `golangci-lint`
* Update linter settings for `golangci-lint`
* Skip execution of some `golangci-lint` linters on Go test files
* Upgrade `actions/checkout` workflow to `v2`
* Add `go fix` to `validate` Action workflow