### PR TITLE
fix: using config file with CLI

### DIFF
--- a/action/config/validate.go
+++ b/action/config/validate.go
@@ -20,15 +20,18 @@ func (c *Config) Validate() error {
 		return fmt.Errorf("no config file provided")
 	}
 
-	// check if config file exists
-	_, err := os.Stat(c.File)
-	if err != nil {
-		// check if a not exist err was returned
-		if os.IsNotExist(err) {
-			return fmt.Errorf("no config file found @ %s", c.File)
-		}
+	// check if config action is generate
+	if c.Action != "generate" {
+		// check if config file exists
+		_, err := os.Stat(c.File)
+		if err != nil {
+			// check if a not exist err was returned
+			if os.IsNotExist(err) {
+				return fmt.Errorf("no config file found @ %s", c.File)
+			}
 
-		return err
+			return err
+		}
 	}
 
 	return nil

--- a/action/config/view.go
+++ b/action/config/view.go
@@ -36,5 +36,5 @@ func (c *Config) View() error {
 	// output the config in stdout format
 	//
 	// https://pkg.go.dev/github.com/go-vela/cli/internal/output?tab=doc#Stdout
-	return output.Stdout(config)
+	return output.Stdout(string(config))
 }

--- a/action/config_generate.go
+++ b/action/config_generate.go
@@ -48,7 +48,7 @@ var ConfigGenerate = &cli.Command{
 			EnvVars: []string{"VELA_LOG_LEVEL", "CONFIG_LOG_LEVEL"},
 			Name:    "log.level",
 			Aliases: []string{"l"},
-			Usage:   "set the level of logging for the CLI",
+			Usage:   "set the level of logging - options: (trace|debug|info|warn|error|fatal|panic)",
 		},
 
 		// Output Flags
@@ -57,7 +57,7 @@ var ConfigGenerate = &cli.Command{
 			EnvVars: []string{"VELA_OUTPUT", "CONFIG_OUTPUT"},
 			Name:    "output",
 			Aliases: []string{"op"},
-			Usage:   "set the type of output for the CLI",
+			Usage:   "format the output in json, spew, or yaml format",
 		},
 
 		// Repo Flags
@@ -118,7 +118,7 @@ func configGenerate(c *cli.Context) error {
 	// https://pkg.go.dev/github.com/go-vela/cli/action/config?tab=doc#Config
 	conf := &config.Config{
 		Action:   generateAction,
-		File:     c.String("file"),
+		File:     c.String("config"),
 		Addr:     c.String(client.KeyAddress),
 		Token:    c.String(client.KeyToken),
 		Version:  c.String("api.version"),

--- a/action/config_generate_test.go
+++ b/action/config_generate_test.go
@@ -14,7 +14,7 @@ import (
 func TestAction_ConfigGenerate(t *testing.T) {
 	// setup flags
 	set := flag.NewFlagSet("test", 0)
-	set.String("file", "config/testdata/generate.yml", "doc")
+	set.String("config", "config/testdata/generate.yml", "doc")
 	set.String("addr", "https://vela-server.localhost", "doc")
 	set.String("token", "superSecretToken", "doc")
 	set.String("api.version", "1", "doc")

--- a/action/config_remove.go
+++ b/action/config_remove.go
@@ -119,7 +119,7 @@ func configRemove(c *cli.Context) error {
 	// https://pkg.go.dev/github.com/go-vela/cli/action/config?tab=doc#Config
 	conf := &config.Config{
 		Action: removeAction,
-		File:   c.String("file"),
+		File:   c.String("config"),
 	}
 
 	// check if the API addr flag should be removed

--- a/action/config_remove_test.go
+++ b/action/config_remove_test.go
@@ -14,7 +14,7 @@ import (
 func TestAction_ConfigRemove(t *testing.T) {
 	// setup flags
 	set := flag.NewFlagSet("test", 0)
-	set.String("file", "config/testdata/remove.yml", "doc")
+	set.String("config", "config/testdata/remove.yml", "doc")
 	set.Bool("addr", true, "doc")
 	set.Bool("token", true, "doc")
 	set.Bool("api.version", true, "doc")

--- a/action/config_update.go
+++ b/action/config_update.go
@@ -118,7 +118,7 @@ func configUpdate(c *cli.Context) error {
 	// https://pkg.go.dev/github.com/go-vela/cli/action/config?tab=doc#Config
 	conf := &config.Config{
 		Action:      updateAction,
-		File:        c.String("file"),
+		File:        c.String("config"),
 		UpdateFlags: make(map[string]string),
 	}
 

--- a/action/config_update_test.go
+++ b/action/config_update_test.go
@@ -14,7 +14,7 @@ import (
 func TestAction_ConfigUpdate(t *testing.T) {
 	// setup flags
 	set := flag.NewFlagSet("test", 0)
-	set.String("file", "config/testdata/generate.yml", "doc")
+	set.String("config", "config/testdata/generate.yml", "doc")
 	set.String("addr", "https://vela-server.localhost", "doc")
 	set.String("token", "superSecretToken", "doc")
 	set.String("api.version", "1", "doc")

--- a/action/config_view.go
+++ b/action/config_view.go
@@ -38,7 +38,7 @@ func configView(c *cli.Context) error {
 	// https://pkg.go.dev/github.com/go-vela/cli/action/config?tab=doc#Config
 	conf := &config.Config{
 		Action: viewAction,
-		File:   c.String("file"),
+		File:   c.String("config"),
 	}
 
 	// validate config file configuration

--- a/action/config_view_test.go
+++ b/action/config_view_test.go
@@ -14,7 +14,7 @@ import (
 func TestAction_ConfigView(t *testing.T) {
 	// setup flags
 	set := flag.NewFlagSet("test", 0)
-	set.String("file", "config/testdata/config.yml", "doc")
+	set.String("config", "config/testdata/config.yml", "doc")
 
 	// setup tests
 	tests := []struct {


### PR DESCRIPTION
* skip the `os.Stat()` check for the config file if the action is `generate`
* output the config file as a string if the action is `view`
* switch from `file` flag to global `config` flag when loading the configuration