### PR TITLE
refactor: update main for refactored subcommands

### DIFF
--- a/cmd/vela-cli/add.go
+++ b/cmd/vela-cli/add.go
@@ -12,11 +12,12 @@ import (
 
 // addCmds defines the commands for creating resources.
 var addCmds = &cli.Command{
-	Name:        "add",
-	Category:    "Resource Management",
-	Aliases:     []string{"a"},
-	Description: "Use this command to add resources to Vela.",
-	Usage:       "Add resources to Vela via subcommands",
+	Name:                   "add",
+	Category:               "Resource Management",
+	Aliases:                []string{"a"},
+	Description:            "Use this command to add resources to Vela.",
+	Usage:                  "Add resources to Vela via subcommands",
+	UseShortOptionHandling: true,
 	Subcommands: []*cli.Command{
 		// add the sub command for creating a deployment
 		//

--- a/cmd/vela-cli/chown.go
+++ b/cmd/vela-cli/chown.go
@@ -12,11 +12,12 @@ import (
 
 // chownCmds defines the commands for changing ownership of a resource.
 var chownCmds = &cli.Command{
-	Name:        "chown",
-	Category:    "Resource Management",
-	Aliases:     []string{"c"},
-	Description: "Use this command to change ownership of a resource for Vela.",
-	Usage:       "Change ownership of resources for Vela via subcommands",
+	Name:                   "chown",
+	Category:               "Repository Management",
+	Aliases:                []string{"c"},
+	Description:            "Use this command to change ownership of a resource for Vela.",
+	Usage:                  "Change ownership of resources for Vela via subcommands",
+	UseShortOptionHandling: true,
 	Subcommands: []*cli.Command{
 		// add the sub command for changing ownership of a repository
 		//

--- a/cmd/vela-cli/generate.go
+++ b/cmd/vela-cli/generate.go
@@ -12,12 +12,18 @@ import (
 
 // generateCmds defines the commands for producing resources.
 var generateCmds = &cli.Command{
-	Name:        "generate",
-	Category:    "Resource Management",
-	Aliases:     []string{"gn"},
-	Description: "Use this command to generate resources for Vela.",
-	Usage:       "Generate resources for Vela via subcommands",
+	Name:                   "generate",
+	Category:               "Resource Management",
+	Aliases:                []string{"gn"},
+	Description:            "Use this command to generate resources for Vela.",
+	Usage:                  "Generate resources for Vela via subcommands",
+	UseShortOptionHandling: true,
 	Subcommands: []*cli.Command{
+		// add the sub command for producing a shell auto completion script
+		//
+		// https://pkg.go.dev/github.com/go-vela/cli/action?tab=doc#CompletionGenerate
+		action.CompletionGenerate,
+
 		// add the sub command for producing a config file
 		//
 		// https://pkg.go.dev/github.com/go-vela/cli/action?tab=doc#ConfigGenerate

--- a/cmd/vela-cli/get.go
+++ b/cmd/vela-cli/get.go
@@ -12,11 +12,12 @@ import (
 
 // getCmds defines the commands for getting a list of resources.
 var getCmds = &cli.Command{
-	Name:        "get",
-	Category:    "Resource Management",
-	Aliases:     []string{"g"},
-	Description: "Use this command to get a list of resources for Vela.",
-	Usage:       "Get a list of resources for Vela via subcommands",
+	Name:                   "get",
+	Category:               "Resource Management",
+	Aliases:                []string{"g"},
+	Description:            "Use this command to get a list of resources for Vela.",
+	Usage:                  "Get a list of resources for Vela via subcommands",
+	UseShortOptionHandling: true,
 	Subcommands: []*cli.Command{
 		// add the sub command for getting a list of builds
 		//

--- a/cmd/vela-cli/remove.go
+++ b/cmd/vela-cli/remove.go
@@ -12,11 +12,12 @@ import (
 
 // removeCmds defines the commands for deleting resources.
 var removeCmds = &cli.Command{
-	Name:        "remove",
-	Category:    "Resource Management",
-	Aliases:     []string{"r"},
-	Description: "Use this command to remove a resource for Vela.",
-	Usage:       "Remove a resource for Vela via subcommands",
+	Name:                   "remove",
+	Category:               "Resource Management",
+	Aliases:                []string{"r"},
+	Description:            "Use this command to remove a resource for Vela.",
+	Usage:                  "Remove a resource for Vela via subcommands",
+	UseShortOptionHandling: true,
 	Subcommands: []*cli.Command{
 		// add the sub command for remove a config file
 		//

--- a/cmd/vela-cli/repair.go
+++ b/cmd/vela-cli/repair.go
@@ -12,11 +12,12 @@ import (
 
 // repairCmds defines the commands for repairing resources.
 var repairCmds = &cli.Command{
-	Name:        "repair",
-	Category:    "Resource Management",
-	Aliases:     []string{"rp"},
-	Description: "Use this command to repair a resource for Vela.",
-	Usage:       "Repair a resource for Vela via subcommands",
+	Name:                   "repair",
+	Category:               "Repository Management",
+	Aliases:                []string{"rp"},
+	Description:            "Use this command to repair a resource for Vela.",
+	Usage:                  "Repair a resource for Vela via subcommands",
+	UseShortOptionHandling: true,
 	Subcommands: []*cli.Command{
 		// add the sub command for repairing a repository
 		//

--- a/cmd/vela-cli/restart.go
+++ b/cmd/vela-cli/restart.go
@@ -12,11 +12,12 @@ import (
 
 // restartCmds defines the commands for restarting resources.
 var restartCmds = &cli.Command{
-	Name:        "restart",
-	Category:    "Resource Management",
-	Aliases:     []string{"rs"},
-	Description: "Use this command to restart a resource for Vela.",
-	Usage:       "Restart a resource for Vela via subcommands",
+	Name:                   "restart",
+	Category:               "Pipeline Management",
+	Aliases:                []string{"rs"},
+	Description:            "Use this command to restart a resource for Vela.",
+	Usage:                  "Restart a resource for Vela via subcommands",
+	UseShortOptionHandling: true,
 	Subcommands: []*cli.Command{
 		// add the sub command for restarting a build
 		//

--- a/cmd/vela-cli/update.go
+++ b/cmd/vela-cli/update.go
@@ -12,11 +12,12 @@ import (
 
 // updateCmds defines the commands for modifying resources.
 var updateCmds = &cli.Command{
-	Name:        "update",
-	Category:    "Resource Management",
-	Aliases:     []string{"u"},
-	Description: "Use this command to update a resource for Vela.",
-	Usage:       "Update a resource for Vela via subcommands",
+	Name:                   "update",
+	Category:               "Resource Management",
+	Aliases:                []string{"u"},
+	Description:            "Use this command to update a resource for Vela.",
+	Usage:                  "Update a resource for Vela via subcommands",
+	UseShortOptionHandling: true,
 	Subcommands: []*cli.Command{
 		// add the sub command for modifying a config file
 		//

--- a/cmd/vela-cli/validate.go
+++ b/cmd/vela-cli/validate.go
@@ -12,11 +12,12 @@ import (
 
 // validateCmds defines the commands for validating resources.
 var validateCmds = &cli.Command{
-	Name:        "validate",
-	Category:    "Resource Management",
-	Aliases:     []string{"vd"},
-	Description: "Use this command to validate a resource for Vela.",
-	Usage:       "Validate a resource for Vela via subcommands",
+	Name:                   "validate",
+	Category:               "Pipeline Management",
+	Aliases:                []string{"vd"},
+	Description:            "Use this command to validate a resource for Vela.",
+	Usage:                  "Validate a resource for Vela via subcommands",
+	UseShortOptionHandling: true,
 	Subcommands: []*cli.Command{
 		// add the sub command for validating a pipeline
 		//

--- a/cmd/vela-cli/view.go
+++ b/cmd/vela-cli/view.go
@@ -12,11 +12,12 @@ import (
 
 // viewCmds defines the commands for inspecting resources.
 var viewCmds = &cli.Command{
-	Name:        "view",
-	Category:    "Resource Management",
-	Aliases:     []string{"v"},
-	Description: "Use this command to view a resource for Vela.",
-	Usage:       "View details for a resource for Vela via subcommands",
+	Name:                   "view",
+	Category:               "Resource Management",
+	Aliases:                []string{"v"},
+	Description:            "Use this command to view a resource for Vela.",
+	Usage:                  "View details for a resource for Vela via subcommands",
+	UseShortOptionHandling: true,
 	Subcommands: []*cli.Command{
 		// add the sub command for inspecting a build
 		//


### PR DESCRIPTION
* organized the `main.go` into segments with comments
* cleaned up the global flags set in `main.go`
* update the `main.go` to use the private (local) subcommands setup in the package
* removed unnecessary `validate` function
* enabled `ShortOptionHandling` for all CLI subcommands

FYI:

https://github.com/urfave/cli/blob/master/docs/v2/manual.md#combining-short-options