### PR TITLE
fix: load empty config file or values to prevent panics

### DIFF
--- a/action/config/empty.go
+++ b/action/config/empty.go
@@ -1,0 +1,76 @@
+// Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+//
+// Use of this source code is governed by the LICENSE file in this repository.
+
+package config
+
+import (
+	"github.com/sirupsen/logrus"
+)
+
+// Empty checks if the config file contains empty values.
+func (c *ConfigFile) Empty() bool {
+	logrus.Debug("checking if config file is empty")
+
+	// check if the API object is nil
+	if c.API != nil {
+		logrus.Trace("checking if API values in config file are empty")
+
+		// check if the API address is set
+		if len(c.API.Address) > 0 {
+			return false
+		}
+
+		// check if the API token is set
+		if len(c.API.Token) > 0 {
+			return false
+		}
+
+		// check if the API version is set
+		if len(c.API.Version) > 0 {
+			return false
+		}
+	}
+
+	// check if the log object is nil
+	if c.Log != nil {
+		logrus.Trace("checking if log values in config file are empty")
+
+		// check if the log level is set
+		if len(c.Log.Level) > 0 {
+			return false
+		}
+	}
+
+	// check if the secret object is nil
+	if c.Secret != nil {
+		logrus.Trace("checking if secret values in config file are empty")
+
+		// check if the secret engine is set
+		if len(c.Secret.Engine) > 0 {
+			return false
+		}
+
+		// check if the secret type is set
+		if len(c.Secret.Type) > 0 {
+			return false
+		}
+	}
+
+	// check if the output is set
+	if len(c.Output) > 0 {
+		return false
+	}
+
+	// check if the org is set
+	if len(c.Org) > 0 {
+		return false
+	}
+
+	// check if the repo is set
+	if len(c.Repo) > 0 {
+		return false
+	}
+
+	return true
+}

--- a/action/config/empty_test.go
+++ b/action/config/empty_test.go
@@ -1,0 +1,114 @@
+// Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+//
+// Use of this source code is governed by the LICENSE file in this repository.
+
+package config
+
+import (
+	"testing"
+)
+
+func TestConfig_ConfigFile_Empty(t *testing.T) {
+	// setup tests
+	tests := []struct {
+		want   bool
+		config *ConfigFile
+	}{
+		{
+			want:   true,
+			config: &ConfigFile{},
+		},
+		{
+			want: false,
+			config: &ConfigFile{
+				API: &API{
+					Address: "https://vela-server.localhost",
+					Token:   "superSecretToken",
+					Version: "1",
+				},
+				Log: &Log{
+					Level: "info",
+				},
+				Secret: &Secret{
+					Engine: "native",
+					Type:   "repo",
+				},
+				Output: "json",
+				Org:    "github",
+				Repo:   "octocat",
+			},
+		},
+		{
+			want: false,
+			config: &ConfigFile{
+				API: &API{
+					Token:   "superSecretToken",
+					Version: "1",
+				},
+			},
+		},
+		{
+			want: false,
+			config: &ConfigFile{
+				API: &API{
+					Version: "1",
+				},
+			},
+		},
+		{
+			want: false,
+			config: &ConfigFile{
+				Log: &Log{
+					Level: "info",
+				},
+			},
+		},
+		{
+			want: false,
+			config: &ConfigFile{
+				Secret: &Secret{
+					Engine: "native",
+					Type:   "repo",
+				},
+			},
+		},
+		{
+			want: false,
+			config: &ConfigFile{
+				Secret: &Secret{
+					Type: "repo",
+				},
+			},
+		},
+		{
+			want: false,
+			config: &ConfigFile{
+				Output: "json",
+				Org:    "github",
+				Repo:   "octocat",
+			},
+		},
+		{
+			want: false,
+			config: &ConfigFile{
+				Org:  "github",
+				Repo: "octocat",
+			},
+		},
+		{
+			want: false,
+			config: &ConfigFile{
+				Repo: "octocat",
+			},
+		},
+	}
+
+	// run tests
+	for _, test := range tests {
+		result := test.config.Empty()
+
+		if result != test.want {
+			t.Errorf("Empty is %t, want %t", result, test.want)
+		}
+	}
+}

--- a/action/config/load.go
+++ b/action/config/load.go
@@ -49,6 +49,8 @@ func (c *Config) Load(ctx *cli.Context) error {
 	}
 
 	// check if the config file is empty
+	//
+	// https://pkg.go.dev/github.com/go-vela/cli/action/config?tab=doc#ConfigFile.Empty
 	if config.Empty() {
 		logrus.Debugf("empty config loaded from %s", c.File)
 

--- a/action/config/load.go
+++ b/action/config/load.go
@@ -48,8 +48,15 @@ func (c *Config) Load(ctx *cli.Context) error {
 		return err
 	}
 
+	// check if the config file is empty
+	if config.Empty() {
+		logrus.Debugf("empty config loaded from %s", c.File)
+
+		return nil
+	}
+
 	// check if the API address is set in the context
-	if !ctx.IsSet(client.KeyAddress) {
+	if !ctx.IsSet(client.KeyAddress) && len(config.API.Address) > 0 {
 		// set the API address field to value from config
 		err = ctx.Set(client.KeyAddress, config.API.Address)
 		if err != nil {
@@ -58,7 +65,7 @@ func (c *Config) Load(ctx *cli.Context) error {
 	}
 
 	// check if the API token is set in the context
-	if !ctx.IsSet(client.KeyToken) {
+	if !ctx.IsSet(client.KeyToken) && len(config.API.Token) > 0 {
 		// set the API token field to value from config
 		err = ctx.Set(client.KeyToken, config.API.Token)
 		if err != nil {
@@ -67,7 +74,7 @@ func (c *Config) Load(ctx *cli.Context) error {
 	}
 
 	// check if the API version is set in the context
-	if !ctx.IsSet("api.version") {
+	if !ctx.IsSet("api.version") && len(config.API.Version) > 0 {
 		// set the API version field to value from config
 		err = ctx.Set("api.version", config.API.Version)
 		if err != nil {
@@ -76,7 +83,7 @@ func (c *Config) Load(ctx *cli.Context) error {
 	}
 
 	// check if the log level is set in the context
-	if !ctx.IsSet("log.level") {
+	if !ctx.IsSet("log.level") && len(config.Log.Level) > 0 {
 		// set the log level field to value from config
 		err = ctx.Set("log.level", config.Log.Level)
 		if err != nil {
@@ -85,7 +92,7 @@ func (c *Config) Load(ctx *cli.Context) error {
 	}
 
 	// check if the output is set in the context
-	if !ctx.IsSet("output") {
+	if !ctx.IsSet("output") && len(config.Output) > 0 {
 		// set the output field to value from config
 		err = ctx.Set("output", config.Output)
 		if err != nil {
@@ -94,7 +101,7 @@ func (c *Config) Load(ctx *cli.Context) error {
 	}
 
 	// check if the org is set in the context
-	if !ctx.IsSet("org") {
+	if !ctx.IsSet("org") && len(config.Org) > 0 {
 		// set the org field to value from config
 		err = ctx.Set("org", config.Org)
 		if err != nil {
@@ -103,7 +110,7 @@ func (c *Config) Load(ctx *cli.Context) error {
 	}
 
 	// check if the repo is set in the context
-	if !ctx.IsSet("repo") {
+	if !ctx.IsSet("repo") && len(config.Repo) > 0 {
 		// set the repo field to value from config
 		err = ctx.Set("repo", config.Repo)
 		if err != nil {
@@ -112,7 +119,7 @@ func (c *Config) Load(ctx *cli.Context) error {
 	}
 
 	// check if the secret engine is set in the context
-	if !ctx.IsSet("secret.engine") {
+	if !ctx.IsSet("secret.engine") && len(config.Secret.Engine) > 0 {
 		// set the secret engine field to value from config
 		err = ctx.Set("secret.engine", config.Secret.Engine)
 		if err != nil {
@@ -121,7 +128,7 @@ func (c *Config) Load(ctx *cli.Context) error {
 	}
 
 	// check if the secret type is set in the context
-	if !ctx.IsSet("secret.type") {
+	if !ctx.IsSet("secret.type") && len(config.Secret.Type) > 0 {
 		// set the secret type field to value from config
 		err = ctx.Set("secret.type", config.Secret.Type)
 		if err != nil {
@@ -129,5 +136,5 @@ func (c *Config) Load(ctx *cli.Context) error {
 		}
 	}
 
-	return err
+	return nil
 }

--- a/action/config/load_test.go
+++ b/action/config/load_test.go
@@ -15,106 +15,16 @@ import (
 
 func TestConfig_Config_Load(t *testing.T) {
 	// setup flags
-	set := flag.NewFlagSet("test", 0)
-	set.String("api.addr", "https://vela-server.localhost", "doc")
-	set.String("api.token", "superSecretToken", "doc")
-	set.String("api.version", "1", "doc")
-	set.String("log.level", "info", "doc")
-	set.String("output", "json", "doc")
-	set.String("org", "github", "doc")
-	set.String("repo", "octocat", "doc")
-	set.String("secret.engine", "native", "doc")
-	set.String("secret.type", "repo", "doc")
-
-	addrSet := flag.NewFlagSet("test", 0)
-	addrSet.String("api.token", "superSecretToken", "doc")
-	addrSet.String("api.version", "1", "doc")
-	addrSet.String("log.level", "info", "doc")
-	addrSet.String("output", "json", "doc")
-	addrSet.String("org", "github", "doc")
-	addrSet.String("repo", "octocat", "doc")
-	addrSet.String("secret.engine", "native", "doc")
-	addrSet.String("secret.type", "repo", "doc")
-
-	tokenSet := flag.NewFlagSet("test", 0)
-	tokenSet.String("api.addr", "https://vela-server.localhost", "doc")
-	tokenSet.String("api.version", "1", "doc")
-	tokenSet.String("log.level", "info", "doc")
-	tokenSet.String("output", "json", "doc")
-	tokenSet.String("org", "github", "doc")
-	tokenSet.String("repo", "octocat", "doc")
-	tokenSet.String("secret.engine", "native", "doc")
-	tokenSet.String("secret.type", "repo", "doc")
-
-	versionSet := flag.NewFlagSet("test", 0)
-	versionSet.String("api.addr", "https://vela-server.localhost", "doc")
-	versionSet.String("api.token", "superSecretToken", "doc")
-	versionSet.String("log.level", "info", "doc")
-	versionSet.String("output", "json", "doc")
-	versionSet.String("org", "github", "doc")
-	versionSet.String("repo", "octocat", "doc")
-	versionSet.String("secret.engine", "native", "doc")
-	versionSet.String("secret.type", "repo", "doc")
-
-	logSet := flag.NewFlagSet("test", 0)
-	logSet.String("api.addr", "https://vela-server.localhost", "doc")
-	logSet.String("api.token", "superSecretToken", "doc")
-	logSet.String("api.version", "1", "doc")
-	logSet.String("output", "json", "doc")
-	logSet.String("org", "github", "doc")
-	logSet.String("repo", "octocat", "doc")
-	logSet.String("secret.engine", "native", "doc")
-	logSet.String("secret.type", "repo", "doc")
-
-	outputSet := flag.NewFlagSet("test", 0)
-	outputSet.String("api.addr", "https://vela-server.localhost", "doc")
-	outputSet.String("api.token", "superSecretToken", "doc")
-	outputSet.String("api.version", "1", "doc")
-	outputSet.String("log.level", "info", "doc")
-	outputSet.String("org", "github", "doc")
-	outputSet.String("repo", "octocat", "doc")
-	outputSet.String("secret.engine", "native", "doc")
-	outputSet.String("secret.type", "repo", "doc")
-
-	orgSet := flag.NewFlagSet("test", 0)
-	orgSet.String("api.addr", "https://vela-server.localhost", "doc")
-	orgSet.String("api.token", "superSecretToken", "doc")
-	orgSet.String("api.version", "1", "doc")
-	orgSet.String("log.level", "info", "doc")
-	orgSet.String("output", "json", "doc")
-	orgSet.String("repo", "octocat", "doc")
-	orgSet.String("secret.engine", "native", "doc")
-	orgSet.String("secret.type", "repo", "doc")
-
-	repoSet := flag.NewFlagSet("test", 0)
-	repoSet.String("api.addr", "https://vela-server.localhost", "doc")
-	repoSet.String("api.token", "superSecretToken", "doc")
-	repoSet.String("api.version", "1", "doc")
-	repoSet.String("log.level", "info", "doc")
-	repoSet.String("output", "json", "doc")
-	repoSet.String("org", "github", "doc")
-	repoSet.String("secret.engine", "native", "doc")
-	repoSet.String("secret.type", "repo", "doc")
-
-	engineSet := flag.NewFlagSet("test", 0)
-	engineSet.String("api.addr", "https://vela-server.localhost", "doc")
-	engineSet.String("api.token", "superSecretToken", "doc")
-	engineSet.String("api.version", "1", "doc")
-	engineSet.String("log.level", "info", "doc")
-	engineSet.String("output", "json", "doc")
-	engineSet.String("org", "github", "doc")
-	engineSet.String("repo", "octocat", "doc")
-	engineSet.String("secret.type", "repo", "doc")
-
-	typeSet := flag.NewFlagSet("test", 0)
-	typeSet.String("api.addr", "https://vela-server.localhost", "doc")
-	typeSet.String("api.token", "superSecretToken", "doc")
-	typeSet.String("api.version", "1", "doc")
-	typeSet.String("log.level", "info", "doc")
-	typeSet.String("output", "json", "doc")
-	typeSet.String("org", "github", "doc")
-	typeSet.String("repo", "octocat", "doc")
-	typeSet.String("secret.engine", "native", "doc")
+	fullSet := flag.NewFlagSet("test", 0)
+	fullSet.String("api.addr", "https://vela-server.localhost", "doc")
+	fullSet.String("api.token", "superSecretToken", "doc")
+	fullSet.String("api.version", "1", "doc")
+	fullSet.String("log.level", "info", "doc")
+	fullSet.String("output", "json", "doc")
+	fullSet.String("org", "github", "doc")
+	fullSet.String("repo", "octocat", "doc")
+	fullSet.String("secret.engine", "native", "doc")
+	fullSet.String("secret.type", "repo", "doc")
 
 	// setup tests
 	tests := []struct {
@@ -128,91 +38,39 @@ func TestConfig_Config_Load(t *testing.T) {
 				Action: "load",
 				File:   "testdata/config.yml",
 			},
-			set: set,
+			set: fullSet,
 		},
 		{
-			failure: true,
+			failure: false,
 			config: &Config{
 				Action: "load",
 				File:   "testdata/config.yml",
 			},
-			set: addrSet,
-		},
-		{
-			failure: true,
-			config: &Config{
-				Action: "load",
-				File:   "testdata/config.yml",
-			},
-			set: tokenSet,
-		},
-		{
-			failure: true,
-			config: &Config{
-				Action: "load",
-				File:   "testdata/config.yml",
-			},
-			set: versionSet,
-		},
-		{
-			failure: true,
-			config: &Config{
-				Action: "load",
-				File:   "testdata/config.yml",
-			},
-			set: logSet,
-		},
-		{
-			failure: true,
-			config: &Config{
-				Action: "load",
-				File:   "testdata/config.yml",
-			},
-			set: outputSet,
-		},
-		{
-			failure: true,
-			config: &Config{
-				Action: "load",
-				File:   "testdata/config.yml",
-			},
-			set: orgSet,
-		},
-		{
-			failure: true,
-			config: &Config{
-				Action: "load",
-				File:   "testdata/config.yml",
-			},
-			set: repoSet,
-		},
-		{
-			failure: true,
-			config: &Config{
-				Action: "load",
-				File:   "testdata/config.yml",
-			},
-			set: engineSet,
-		},
-		{
-			failure: true,
-			config: &Config{
-				Action: "load",
-				File:   "testdata/config.yml",
-			},
-			set: typeSet,
+			set: flag.NewFlagSet("test", 0),
 		},
 	}
 
 	// run tests
 	for _, test := range tests {
+		// setup context
+		ctx := cli.NewContext(nil, test.set, nil)
+
 		// setup filesystem
 		appFS = afero.NewMemMapFs()
 
 		// create test config for generating file
 		config := &Config{
-			Action: "generate",
-			File:   test.config.File,
+			Action:   "generate",
+			File:     test.config.File,
+			Addr:     ctx.String("api.addr"),
+			Token:    ctx.String("api.token"),
+			Version:  ctx.String("api.version"),
+			LogLevel: ctx.String("log.level"),
+			Engine:   ctx.String("secret.engine"),
+			Type:     ctx.String("secret.type"),
+			Output:   ctx.String("output"),
+			Org:      ctx.String("org"),
+			Repo:     ctx.String("repo"),
 		}
 
 		// generate config file
@@ -221,7 +79,7 @@ func TestConfig_Config_Load(t *testing.T) {
 			t.Errorf("unable to generate config: %v", err)
 		}
 
-		err = test.config.Load(cli.NewContext(nil, test.set, nil))
+		err = test.config.Load(ctx)
 
 		if test.failure {
 			if err == nil {


### PR DESCRIPTION
Currently, when attempting to load the configuration file if it's empty (file exists but no content) or if the file has content but values in the file are empty, the CLI will throw panics when setting the values.

This PR adds a `Empty()` function to the `go-vela/cli/action/config.ConfigFile` type so we skip setting any values immediately if none are present 👍 

This will also verify there is content in the values being loaded from the config file before attempting to set them in the context 👍 