### PR TITLE
fix: load config for specific subcommands

### DIFF
--- a/action/action.go
+++ b/action/action.go
@@ -18,6 +18,9 @@ const (
 	// getAction defines the action for getting a list of resources.
 	getAction = "get"
 
+	// loadAction defines the action for loading a resource.
+	loadAction = "load"
+
 	// loginAction defines the action for logging in to Vela.
 	loginAction = "login"
 

--- a/action/build_get.go
+++ b/action/build_get.go
@@ -87,6 +87,12 @@ DOCUMENTATION:
 // input and create the object used to
 // capture a list of builds.
 func buildGet(c *cli.Context) error {
+	// load variables from the config file
+	err := load(c)
+	if err != nil {
+		return err
+	}
+
 	// parse the Vela client from the context
 	//
 	// https://pkg.go.dev/github.com/go-vela/cli/internal/client?tab=doc#Parse

--- a/action/build_restart.go
+++ b/action/build_restart.go
@@ -72,6 +72,12 @@ DOCUMENTATION:
 // input and create the object used to
 // restart a build.
 func buildRestart(c *cli.Context) error {
+	// load variables from the config file
+	err := load(c)
+	if err != nil {
+		return err
+	}
+
 	// parse the Vela client from the context
 	//
 	// https://pkg.go.dev/github.com/go-vela/cli/internal/client?tab=doc#Parse

--- a/action/build_view.go
+++ b/action/build_view.go
@@ -74,6 +74,12 @@ DOCUMENTATION:
 // input and create the object used to
 // inspect a build.
 func buildView(c *cli.Context) error {
+	// load variables from the config file
+	err := load(c)
+	if err != nil {
+		return err
+	}
+
 	// parse the Vela client from the context
 	//
 	// https://pkg.go.dev/github.com/go-vela/cli/internal/client?tab=doc#Parse

--- a/action/completion_generate.go
+++ b/action/completion_generate.go
@@ -56,6 +56,12 @@ DOCUMENTATION:
 // input and create the object used to
 // produce the config file.
 func completionGenerate(c *cli.Context) error {
+	// load variables from the config file
+	err := load(c)
+	if err != nil {
+		return err
+	}
+
 	// create the completion configuration
 	//
 	// https://pkg.go.dev/github.com/go-vela/cli/action/completion?tab=doc#Config
@@ -68,7 +74,7 @@ func completionGenerate(c *cli.Context) error {
 	// validate completion configuration
 	//
 	// https://pkg.go.dev/github.com/go-vela/cli/action/completion?tab=doc#Config.Validate
-	err := comp.Validate()
+	err = comp.Validate()
 	if err != nil {
 		return err
 	}

--- a/action/deployment_add.go
+++ b/action/deployment_add.go
@@ -101,6 +101,12 @@ DOCUMENTATION:
 // input and create the object used to
 // create a deployment.
 func deploymentAdd(c *cli.Context) error {
+	// load variables from the config file
+	err := load(c)
+	if err != nil {
+		return err
+	}
+
 	// parse the Vela client from the context
 	//
 	// https://pkg.go.dev/github.com/go-vela/cli/internal/client?tab=doc#Parse

--- a/action/deployment_get.go
+++ b/action/deployment_get.go
@@ -87,6 +87,12 @@ DOCUMENTATION:
 // input and create the object used to
 // capture a list of deployments.
 func deploymentGet(c *cli.Context) error {
+	// load variables from the config file
+	err := load(c)
+	if err != nil {
+		return err
+	}
+
 	// parse the Vela client from the context
 	//
 	// https://pkg.go.dev/github.com/go-vela/cli/internal/client?tab=doc#Parse

--- a/action/deployment_view.go
+++ b/action/deployment_view.go
@@ -74,6 +74,12 @@ DOCUMENTATION:
 // input and create the object used to
 // inspect a deployment.
 func deploymentView(c *cli.Context) error {
+	// load variables from the config file
+	err := load(c)
+	if err != nil {
+		return err
+	}
+
 	// parse the Vela client from the context
 	//
 	// https://pkg.go.dev/github.com/go-vela/cli/internal/client?tab=doc#Parse

--- a/action/hook_get.go
+++ b/action/hook_get.go
@@ -87,6 +87,12 @@ DOCUMENTATION:
 // input and create the object used to
 // capture a list of hooks.
 func hookGet(c *cli.Context) error {
+	// load variables from the config file
+	err := load(c)
+	if err != nil {
+		return err
+	}
+
 	// parse the Vela client from the context
 	//
 	// https://pkg.go.dev/github.com/go-vela/cli/internal/client?tab=doc#Parse

--- a/action/hook_view.go
+++ b/action/hook_view.go
@@ -74,6 +74,12 @@ DOCUMENTATION:
 // input and create the object used to
 // inspect a hook.
 func hookView(c *cli.Context) error {
+	// load variables from the config file
+	err := load(c)
+	if err != nil {
+		return err
+	}
+
 	// parse the Vela client from the context
 	//
 	// https://pkg.go.dev/github.com/go-vela/cli/internal/client?tab=doc#Parse

--- a/action/load.go
+++ b/action/load.go
@@ -2,12 +2,10 @@
 //
 // Use of this source code is governed by the LICENSE file in this repository.
 
-package main
+package action
 
 import (
 	"github.com/go-vela/cli/action/config"
-
-	"github.com/sirupsen/logrus"
 
 	"github.com/urfave/cli/v2"
 )
@@ -18,7 +16,7 @@ func load(c *cli.Context) error {
 	//
 	// https://pkg.go.dev/github.com/go-vela/cli/action/config?tab=doc#Config
 	conf := &config.Config{
-		Action: "load",
+		Action: loadAction,
 		File:   c.String("config"),
 	}
 
@@ -34,26 +32,6 @@ func load(c *cli.Context) error {
 		if err != nil {
 			return err
 		}
-	}
-
-	// set log level for the CLI
-	switch c.String("log.level") {
-	case "t", "trace", "Trace", "TRACE":
-		logrus.SetLevel(logrus.TraceLevel)
-	case "d", "debug", "Debug", "DEBUG":
-		logrus.SetLevel(logrus.DebugLevel)
-	case "w", "warn", "Warn", "WARN":
-		logrus.SetLevel(logrus.WarnLevel)
-	case "e", "error", "Error", "ERROR":
-		logrus.SetLevel(logrus.ErrorLevel)
-	case "f", "fatal", "Fatal", "FATAL":
-		logrus.SetLevel(logrus.FatalLevel)
-	case "p", "panic", "Panic", "PANIC":
-		logrus.SetLevel(logrus.PanicLevel)
-	case "i", "info", "Info", "INFO":
-		fallthrough
-	default:
-		logrus.SetLevel(logrus.InfoLevel)
 	}
 
 	return nil

--- a/action/load_test.go
+++ b/action/load_test.go
@@ -1,0 +1,74 @@
+// Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+//
+// Use of this source code is governed by the LICENSE file in this repository.
+
+package action
+
+import (
+	"flag"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-vela/mock/server"
+
+	"github.com/urfave/cli/v2"
+)
+
+func TestAction_load(t *testing.T) {
+	// setup test server
+	s := httptest.NewServer(server.FakeHandler())
+
+	// setup flags
+	authSet := flag.NewFlagSet("test", 0)
+	authSet.String("config", "config/testdata/empty.yml", "doc")
+	authSet.String("api.addr", s.URL, "doc")
+	authSet.String("api.token", "superSecretToken", "doc")
+
+	fullSet := flag.NewFlagSet("test", 0)
+	fullSet.String("config", "config/testdata/empty.yml", "doc")
+	fullSet.String("api.addr", "https://vela-server.localhost", "doc")
+	fullSet.String("api.token", "superSecretToken", "doc")
+	fullSet.String("api.version", "1", "doc")
+	fullSet.String("log.level", "info", "doc")
+	fullSet.String("output", "json", "doc")
+	fullSet.String("org", "github", "doc")
+	fullSet.String("repo", "octocat", "doc")
+	fullSet.String("secret.engine", "native", "doc")
+	fullSet.String("secret.type", "repo", "doc")
+
+	// setup tests
+	tests := []struct {
+		failure bool
+		set     *flag.FlagSet
+	}{
+		{
+			failure: false,
+			set:     fullSet,
+		},
+		{
+			failure: false,
+			set:     authSet,
+		},
+		{
+			failure: false,
+			set:     flag.NewFlagSet("test", 0),
+		},
+	}
+
+	// run tests
+	for _, test := range tests {
+		err := load(cli.NewContext(nil, test.set, nil))
+
+		if test.failure {
+			if err == nil {
+				t.Errorf("load should have returned err")
+			}
+
+			continue
+		}
+
+		if err != nil {
+			t.Errorf("load returned err: %v", err)
+		}
+	}
+}

--- a/action/log_get.go
+++ b/action/log_get.go
@@ -77,6 +77,12 @@ DOCUMENTATION:
 // input and create the object used to
 // capture a list of build logs.
 func logGet(c *cli.Context) error {
+	// load variables from the config file
+	err := load(c)
+	if err != nil {
+		return err
+	}
+
 	// parse the Vela client from the context
 	//
 	// https://pkg.go.dev/github.com/go-vela/cli/internal/client?tab=doc#Parse

--- a/action/log_view.go
+++ b/action/log_view.go
@@ -96,6 +96,12 @@ DOCUMENTATION:
 // input and create the object used to
 // inspect a log.
 func logView(c *cli.Context) error {
+	// load variables from the config file
+	err := load(c)
+	if err != nil {
+		return err
+	}
+
 	// parse the Vela client from the context
 	//
 	// https://pkg.go.dev/github.com/go-vela/cli/internal/client?tab=doc#Parse

--- a/action/login.go
+++ b/action/login.go
@@ -70,6 +70,12 @@ DOCUMENTATION:
 // input and create the object used to
 //  authenticate and login to Vela.
 func runLogin(c *cli.Context) error {
+	// load variables from the config file
+	err := load(c)
+	if err != nil {
+		return err
+	}
+
 	// parse the Vela client from the context
 	//
 	// https://pkg.go.dev/github.com/go-vela/cli/internal/client?tab=doc#ParseEmptyToken

--- a/action/repo_add.go
+++ b/action/repo_add.go
@@ -130,6 +130,12 @@ DOCUMENTATION:
 // input and create the object used to
 // create a repo.
 func repoAdd(c *cli.Context) error {
+	// load variables from the config file
+	err := load(c)
+	if err != nil {
+		return err
+	}
+
 	// parse the Vela client from the context
 	//
 	// https://pkg.go.dev/github.com/go-vela/cli/internal/client?tab=doc#Parse

--- a/action/repo_chown.go
+++ b/action/repo_chown.go
@@ -65,6 +65,12 @@ DOCUMENTATION:
 // input and create the object used to
 // change ownership of a repository.
 func repoChown(c *cli.Context) error {
+	// load variables from the config file
+	err := load(c)
+	if err != nil {
+		return err
+	}
+
 	// parse the Vela client from the context
 	//
 	// https://pkg.go.dev/github.com/go-vela/cli/internal/client?tab=doc#Parse

--- a/action/repo_get.go
+++ b/action/repo_get.go
@@ -72,6 +72,12 @@ DOCUMENTATION:
 // input and create the object used to
 // capture a list of repos.
 func repoGet(c *cli.Context) error {
+	// load variables from the config file
+	err := load(c)
+	if err != nil {
+		return err
+	}
+
 	// parse the Vela client from the context
 	//
 	// https://pkg.go.dev/github.com/go-vela/cli/internal/client?tab=doc#Parse

--- a/action/repo_remove.go
+++ b/action/repo_remove.go
@@ -65,6 +65,12 @@ DOCUMENTATION:
 // input and create the object used to
 // remove a repository.
 func repoRemove(c *cli.Context) error {
+	// load variables from the config file
+	err := load(c)
+	if err != nil {
+		return err
+	}
+
 	// parse the Vela client from the context
 	//
 	// https://pkg.go.dev/github.com/go-vela/cli/internal/client?tab=doc#Parse

--- a/action/repo_repair.go
+++ b/action/repo_repair.go
@@ -65,6 +65,12 @@ DOCUMENTATION:
 // input and create the object used to
 // repair settings of a repository.
 func repoRepair(c *cli.Context) error {
+	// load variables from the config file
+	err := load(c)
+	if err != nil {
+		return err
+	}
+
 	// parse the Vela client from the context
 	//
 	// https://pkg.go.dev/github.com/go-vela/cli/internal/client?tab=doc#Parse

--- a/action/repo_update.go
+++ b/action/repo_update.go
@@ -130,6 +130,12 @@ DOCUMENTATION:
 // input and create the object used to
 // modify a repository.
 func repoUpdate(c *cli.Context) error {
+	// load variables from the config file
+	err := load(c)
+	if err != nil {
+		return err
+	}
+
 	// parse the Vela client from the context
 	//
 	// https://pkg.go.dev/github.com/go-vela/cli/internal/client?tab=doc#Parse

--- a/action/repo_view.go
+++ b/action/repo_view.go
@@ -65,6 +65,12 @@ DOCUMENTATION:
 // input and create the object used to
 // inspect a repository.
 func repoView(c *cli.Context) error {
+	// load variables from the config file
+	err := load(c)
+	if err != nil {
+		return err
+	}
+
 	// parse the Vela client from the context
 	//
 	// https://pkg.go.dev/github.com/go-vela/cli/internal/client?tab=doc#Parse

--- a/action/secret_add.go
+++ b/action/secret_add.go
@@ -144,6 +144,12 @@ DOCUMENTATION:
 // input and create the object used to
 // create a secret.
 func secretAdd(c *cli.Context) error {
+	// load variables from the config file
+	err := load(c)
+	if err != nil {
+		return err
+	}
+
 	// parse the Vela client from the context
 	//
 	// https://pkg.go.dev/github.com/go-vela/cli/internal/client?tab=doc#Parse

--- a/action/secret_get.go
+++ b/action/secret_get.go
@@ -111,6 +111,12 @@ DOCUMENTATION:
 // input and create the object used to
 // capture a list of secrets.
 func secretGet(c *cli.Context) error {
+	// load variables from the config file
+	err := load(c)
+	if err != nil {
+		return err
+	}
+
 	// parse the Vela client from the context
 	//
 	// https://pkg.go.dev/github.com/go-vela/cli/internal/client?tab=doc#Parse

--- a/action/secret_remove.go
+++ b/action/secret_remove.go
@@ -100,6 +100,12 @@ DOCUMENTATION:
 // input and create the object used to
 // remove a secret.
 func secretRemove(c *cli.Context) error {
+	// load variables from the config file
+	err := load(c)
+	if err != nil {
+		return err
+	}
+
 	// parse the Vela client from the context
 	//
 	// https://pkg.go.dev/github.com/go-vela/cli/internal/client?tab=doc#Parse

--- a/action/secret_update.go
+++ b/action/secret_update.go
@@ -144,6 +144,12 @@ DOCUMENTATION:
 // input and create the object used to
 // modify a secret.
 func secretUpdate(c *cli.Context) error {
+	// load variables from the config file
+	err := load(c)
+	if err != nil {
+		return err
+	}
+
 	// parse the Vela client from the context
 	//
 	// https://pkg.go.dev/github.com/go-vela/cli/internal/client?tab=doc#Parse

--- a/action/secret_view.go
+++ b/action/secret_view.go
@@ -100,6 +100,12 @@ DOCUMENTATION:
 // input and create the object used to
 // inspect a secret.
 func secretView(c *cli.Context) error {
+	// load variables from the config file
+	err := load(c)
+	if err != nil {
+		return err
+	}
+
 	// parse the Vela client from the context
 	//
 	// https://pkg.go.dev/github.com/go-vela/cli/internal/client?tab=doc#Parse

--- a/action/service_get.go
+++ b/action/service_get.go
@@ -96,6 +96,12 @@ DOCUMENTATION:
 // input and create the object used to
 // capture a list of services.
 func serviceGet(c *cli.Context) error {
+	// load variables from the config file
+	err := load(c)
+	if err != nil {
+		return err
+	}
+
 	// parse the Vela client from the context
 	//
 	// https://pkg.go.dev/github.com/go-vela/cli/internal/client?tab=doc#Parse

--- a/action/service_view.go
+++ b/action/service_view.go
@@ -83,6 +83,12 @@ DOCUMENTATION:
 // input and create the object used to
 // inspect a service.
 func serviceView(c *cli.Context) error {
+	// load variables from the config file
+	err := load(c)
+	if err != nil {
+		return err
+	}
+
 	// parse the Vela client from the context
 	//
 	// https://pkg.go.dev/github.com/go-vela/cli/internal/client?tab=doc#Parse

--- a/action/step_get.go
+++ b/action/step_get.go
@@ -96,6 +96,12 @@ DOCUMENTATION:
 // input and create the object used to
 // capture a list of steps.
 func stepGet(c *cli.Context) error {
+	// load variables from the config file
+	err := load(c)
+	if err != nil {
+		return err
+	}
+
 	// parse the Vela client from the context
 	//
 	// https://pkg.go.dev/github.com/go-vela/cli/internal/client?tab=doc#Parse

--- a/action/step_view.go
+++ b/action/step_view.go
@@ -83,6 +83,12 @@ DOCUMENTATION:
 // input and create the object used to
 // inspect a step.
 func stepView(c *cli.Context) error {
+	// load variables from the config file
+	err := load(c)
+	if err != nil {
+		return err
+	}
+
 	// parse the Vela client from the context
 	//
 	// https://pkg.go.dev/github.com/go-vela/cli/internal/client?tab=doc#Parse

--- a/cmd/vela-cli/log.go
+++ b/cmd/vela-cli/log.go
@@ -1,0 +1,36 @@
+// Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+//
+// Use of this source code is governed by the LICENSE file in this repository.
+
+package main
+
+import (
+	"github.com/sirupsen/logrus"
+
+	"github.com/urfave/cli/v2"
+)
+
+// setLogging is a helper function that sets up logging for the CLI.
+func setLogging(c *cli.Context) error {
+	// set log level for the CLI
+	switch c.String("log.level") {
+	case "t", "trace", "Trace", "TRACE":
+		logrus.SetLevel(logrus.TraceLevel)
+	case "d", "debug", "Debug", "DEBUG":
+		logrus.SetLevel(logrus.DebugLevel)
+	case "w", "warn", "Warn", "WARN":
+		logrus.SetLevel(logrus.WarnLevel)
+	case "e", "error", "Error", "ERROR":
+		logrus.SetLevel(logrus.ErrorLevel)
+	case "f", "fatal", "Fatal", "FATAL":
+		logrus.SetLevel(logrus.FatalLevel)
+	case "p", "panic", "Panic", "PANIC":
+		logrus.SetLevel(logrus.PanicLevel)
+	case "i", "info", "Info", "INFO":
+		fallthrough
+	default:
+		logrus.SetLevel(logrus.InfoLevel)
+	}
+
+	return nil
+}

--- a/cmd/vela-cli/main.go
+++ b/cmd/vela-cli/main.go
@@ -36,7 +36,7 @@ func main() {
 
 	// CLI Metadata
 
-	app.Before = load
+	app.Before = setLogging
 	app.Compiled = time.Now()
 	app.EnableBashCompletion = true
 	app.UseShortOptionHandling = true


### PR DESCRIPTION
Currently, we load the CLI configuration file **on every execution of the CLI**.

The problem with this is not all functions require the configuration file to be loaded to execute the command.

At this time, examples include:

* interactions with the CLI configuration file
* interactions with Vela pipelines

This PR moves the loading of the CLI configuration file to the subcommands that require it in the `go-vela/cli/action` package 👍

To be clear, the bug that is caused by the current behavior is failures to operate on the `config` resource after it has already been generated.

This also should improve the user experience if running the CLI in `debug` or `trace` level logging because you will no longer see messages "failing to load the config" when executing actions on the `config` resource itself.

