### PR TITLE
fix: remove unusable global flags

### DIFF
--- a/action/config/load.go
+++ b/action/config/load.go
@@ -51,8 +51,9 @@ func (c *Config) Load(ctx *cli.Context) error {
 	// check if the config file is empty
 	//
 	// https://pkg.go.dev/github.com/go-vela/cli/action/config?tab=doc#ConfigFile.Empty
+	// nolint:lll // log message is too long
 	if config.Empty() {
-		logrus.Warningf("empty or unsupported config loaded from %s", c.File)
+		logrus.Warningf("empty/unsupported config loaded from %s - fix this with `vela generate config`", c.File)
 
 		return nil
 	}

--- a/action/config/load.go
+++ b/action/config/load.go
@@ -52,7 +52,7 @@ func (c *Config) Load(ctx *cli.Context) error {
 	//
 	// https://pkg.go.dev/github.com/go-vela/cli/action/config?tab=doc#ConfigFile.Empty
 	if config.Empty() {
-		logrus.Debugf("empty config loaded from %s", c.File)
+		logrus.Warningf("empty or unsupported config loaded from %s", c.File)
 
 		return nil
 	}

--- a/action/load.go
+++ b/action/load.go
@@ -7,6 +7,8 @@ package action
 import (
 	"github.com/go-vela/cli/action/config"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/urfave/cli/v2"
 )
 
@@ -32,6 +34,26 @@ func load(c *cli.Context) error {
 		if err != nil {
 			return err
 		}
+	}
+
+	// set log level for the CLI
+	switch c.String("log.level") {
+	case "t", "trace", "Trace", "TRACE":
+		logrus.SetLevel(logrus.TraceLevel)
+	case "d", "debug", "Debug", "DEBUG":
+		logrus.SetLevel(logrus.DebugLevel)
+	case "w", "warn", "Warn", "WARN":
+		logrus.SetLevel(logrus.WarnLevel)
+	case "e", "error", "Error", "ERROR":
+		logrus.SetLevel(logrus.ErrorLevel)
+	case "f", "fatal", "Fatal", "FATAL":
+		logrus.SetLevel(logrus.FatalLevel)
+	case "p", "panic", "Panic", "PANIC":
+		logrus.SetLevel(logrus.PanicLevel)
+	case "i", "info", "Info", "INFO":
+		fallthrough
+	default:
+		logrus.SetLevel(logrus.InfoLevel)
 	}
 
 	return nil

--- a/action/load.go
+++ b/action/load.go
@@ -6,6 +6,7 @@ package action
 
 import (
 	"github.com/go-vela/cli/action/config"
+	"github.com/go-vela/cli/internal"
 
 	"github.com/sirupsen/logrus"
 
@@ -19,7 +20,7 @@ func load(c *cli.Context) error {
 	// https://pkg.go.dev/github.com/go-vela/cli/action/config?tab=doc#Config
 	conf := &config.Config{
 		Action: loadAction,
-		File:   c.String("config"),
+		File:   c.String(internal.FlagConfig),
 	}
 
 	// validate config file configuration
@@ -37,7 +38,7 @@ func load(c *cli.Context) error {
 	}
 
 	// set log level for the CLI
-	switch c.String("log.level") {
+	switch c.String(internal.FlagLogLevel) {
 	case "t", "trace", "Trace", "TRACE":
 		logrus.SetLevel(logrus.TraceLevel)
 	case "d", "debug", "Debug", "DEBUG":

--- a/cmd/vela-cli/log.go
+++ b/cmd/vela-cli/log.go
@@ -5,6 +5,8 @@
 package main
 
 import (
+	"github.com/go-vela/cli/internal"
+
 	"github.com/sirupsen/logrus"
 
 	"github.com/urfave/cli/v2"
@@ -13,7 +15,7 @@ import (
 // setLogging is a helper function that sets up logging for the CLI.
 func setLogging(c *cli.Context) error {
 	// set log level for the CLI
-	switch c.String("log.level") {
+	switch c.String(internal.FlagLogLevel) {
 	case "t", "trace", "Trace", "TRACE":
 		logrus.SetLevel(logrus.TraceLevel)
 	case "d", "debug", "Debug", "DEBUG":

--- a/cmd/vela-cli/main.go
+++ b/cmd/vela-cli/main.go
@@ -103,45 +103,6 @@ func main() {
 			Usage:   "set the level of logging - options: (trace|debug|info|warn|error|fatal|panic)",
 			Value:   "info",
 		},
-
-		// Output Flags
-
-		&cli.StringFlag{
-			EnvVars: []string{"VELA_OUTPUT", "CONFIG_OUTPUT"},
-			Name:    internal.FlagOutput,
-			Aliases: []string{"op"},
-			Usage:   "set the type of output - options: (json|spew|yaml)",
-		},
-
-		// Repo Flags
-
-		&cli.StringFlag{
-			EnvVars: []string{"VELA_ORG", "CONFIG_ORG"},
-			Name:    internal.FlagOrg,
-			Aliases: []string{"o"},
-			Usage:   "provide the organization for the CLI",
-		},
-		&cli.StringFlag{
-			EnvVars: []string{"VELA_REPO", "CONFIG_REPO"},
-			Name:    internal.FlagRepo,
-			Aliases: []string{"r"},
-			Usage:   "provide the repository for the CLI",
-		},
-
-		// Secret Flags
-
-		&cli.StringFlag{
-			EnvVars: []string{"VELA_ENGINE", "CONFIG_ENGINE", "SECRET_ENGINE"},
-			Name:    internal.FlagSecretEngine,
-			Aliases: []string{"e"},
-			Usage:   "provide the secret engine for the CLI",
-		},
-		&cli.StringFlag{
-			EnvVars: []string{"VELA_TYPE", "CONFIG_TYPE", "SECRET_TYPE"},
-			Name:    internal.FlagSecretType,
-			Aliases: []string{"ty"},
-			Usage:   "provide the secret type for the CLI",
-		},
 	}
 
 	// CLI Start


### PR DESCRIPTION
This PR removes some of the global flags that are unusable in the `github.com/urfave/cli/v2` library.

The reason these flags no longer work is because some of these global flags are redeclared in each subcommand which will overwrite any value specified at the global level.

Although we are removing the global flags, technically you can still provide values at a "global" level by using the environment variables or the configuration file 👍 