### PR TITLE
enhancement: swap image to alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN apk add --update --no-cache ca-certificates
 #  docker build -t target/vela-cli:latest .     #
 #################################################
 
-FROM scratch
+FROM alpine:3
 
 COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 


### PR DESCRIPTION
This PR will move the image from `scratch` to `alpine`.

We have customers who are looking to use this image in `commands:` blocks of pipelines and that requires using an image with `sh`

Example:

```yaml
steps:
  - name: repo
    image: target/vela-cli:latest
    commands:
      - vela get repo
```