### PR TITLE
fix: loading config file for CLI commands

### DIFF
--- a/action/config/load.go
+++ b/action/config/load.go
@@ -5,6 +5,8 @@
 package config
 
 import (
+	"strings"
+
 	"github.com/go-vela/cli/internal"
 
 	"github.com/sirupsen/logrus"
@@ -19,6 +21,18 @@ import (
 // Load reads the config file and sets the values based off the provided configuration.
 func (c *Config) Load(ctx *cli.Context) error {
 	logrus.Debug("executing load for config file configuration")
+
+	// check if we're operating on the config resource
+	for _, arg := range ctx.Args().Slice() {
+		// check if we're operating on the config resource
+		//
+		// nolint:lll // log message is too long
+		if strings.Contains(arg, "config") {
+			logrus.Debugf("config arg provided in %v - skipping load for config file %s", ctx.Args().Slice(), c.File)
+
+			return nil
+		}
+	}
 
 	// use custom filesystem which enables us to test
 	//

--- a/action/config/load.go
+++ b/action/config/load.go
@@ -72,84 +72,146 @@ func (c *Config) Load(ctx *cli.Context) error {
 		return nil
 	}
 
-	// check if the API address is set in the context
-	if !ctx.IsSet(internal.FlagAPIAddress) && len(config.API.Address) > 0 {
-		// set the API address field to value from config
-		err = ctx.Set(internal.FlagAPIAddress, config.API.Address)
-		if err != nil {
-			return err
-		}
+	// capture a list of all available flags to set in the current context
+	flags := []cli.Flag{}
+	// check if the app is provided in the context
+	if ctx.App != nil {
+		// append the flags from the app provided
+		flags = append(flags, ctx.App.VisibleFlags()...)
+	}
+	// check if the command is provided in the context
+	if ctx.Command != nil {
+		// append the flags from the context provided
+		flags = append(flags, ctx.Command.VisibleFlags()...)
 	}
 
-	// check if the API token is set in the context
-	if !ctx.IsSet(internal.FlagAPIToken) && len(config.API.Token) > 0 {
-		// set the API token field to value from config
-		err = ctx.Set(internal.FlagAPIToken, config.API.Token)
-		if err != nil {
-			return err
-		}
-	}
+	// iterate thro ugh all available flags in the current context
+	for _, flag := range flags {
+		// capture string value for flag
+		f := strings.Join(flag.Names(), " ")
 
-	// check if the API version is set in the context
-	if !ctx.IsSet(internal.FlagAPIVersion) && len(config.API.Version) > 0 {
-		// set the API version field to value from config
-		err = ctx.Set(internal.FlagAPIVersion, config.API.Version)
-		if err != nil {
-			return err
-		}
-	}
+		// check if the API address flag is available
+		// and if it is set in the context
+		if strings.Contains(f, internal.FlagAPIAddress) &&
+			!ctx.IsSet(internal.FlagAPIAddress) &&
+			len(config.API.Address) > 0 {
+			// set the API address field to value from config
+			err = ctx.Set(internal.FlagAPIAddress, config.API.Address)
+			if err != nil {
+				return err
+			}
 
-	// check if the log level is set in the context
-	if !ctx.IsSet(internal.FlagLogLevel) && len(config.Log.Level) > 0 {
-		// set the log level field to value from config
-		err = ctx.Set(internal.FlagLogLevel, config.Log.Level)
-		if err != nil {
-			return err
+			continue
 		}
-	}
 
-	// check if the output is set in the context
-	if !ctx.IsSet(internal.FlagOutput) && len(config.Output) > 0 {
-		// set the output field to value from config
-		err = ctx.Set(internal.FlagOutput, config.Output)
-		if err != nil {
-			return err
+		// check if the API token flag is available
+		// and if it is set in the context
+		if strings.Contains(f, internal.FlagAPIToken) &&
+			!ctx.IsSet(internal.FlagAPIToken) &&
+			len(config.API.Token) > 0 {
+			// set the API token field to value from config
+			err = ctx.Set(internal.FlagAPIToken, config.API.Token)
+			if err != nil {
+				return err
+			}
+
+			continue
 		}
-	}
 
-	// check if the org is set in the context
-	if !ctx.IsSet(internal.FlagOrg) && len(config.Org) > 0 {
-		// set the org field to value from config
-		err = ctx.Set(internal.FlagOrg, config.Org)
-		if err != nil {
-			return err
+		// check if the API version flag is available
+		// and if it is set in the context
+		if strings.Contains(f, internal.FlagAPIVersion) &&
+			!ctx.IsSet(internal.FlagAPIVersion) &&
+			len(config.API.Version) > 0 {
+			// set the API version field to value from config
+			err = ctx.Set(internal.FlagAPIVersion, config.API.Version)
+			if err != nil {
+				return err
+			}
+
+			continue
 		}
-	}
 
-	// check if the repo is set in the context
-	if !ctx.IsSet(internal.FlagRepo) && len(config.Repo) > 0 {
-		// set the repo field to value from config
-		err = ctx.Set(internal.FlagRepo, config.Repo)
-		if err != nil {
-			return err
+		// check if the log level flag is available
+		// and if it is set in the context
+		if strings.Contains(f, internal.FlagLogLevel) &&
+			!ctx.IsSet(internal.FlagLogLevel) &&
+			len(config.Log.Level) > 0 {
+			// set the log level field to value from config
+			err = ctx.Set(internal.FlagLogLevel, config.Log.Level)
+			if err != nil {
+				return err
+			}
 		}
-	}
 
-	// check if the secret engine is set in the context
-	if !ctx.IsSet(internal.FlagSecretEngine) && len(config.Secret.Engine) > 0 {
-		// set the secret engine field to value from config
-		err = ctx.Set(internal.FlagSecretEngine, config.Secret.Engine)
-		if err != nil {
-			return err
+		// check if the output flag is available
+		// and if it is set in the context
+		if strings.Contains(f, internal.FlagOutput) &&
+			!ctx.IsSet(internal.FlagOutput) &&
+			len(config.Output) > 0 {
+			// set the output field to value from config
+			err = ctx.Set(internal.FlagOutput, config.Output)
+			if err != nil {
+				return err
+			}
+
+			continue
 		}
-	}
 
-	// check if the secret type is set in the context
-	if !ctx.IsSet(internal.FlagSecretType) && len(config.Secret.Type) > 0 {
-		// set the secret type field to value from config
-		err = ctx.Set(internal.FlagSecretType, config.Secret.Type)
-		if err != nil {
-			return err
+		// check if the org flag is available
+		// and if it is set in the context
+		if strings.Contains(f, internal.FlagOrg) &&
+			!ctx.IsSet(internal.FlagOrg) &&
+			len(config.Org) > 0 {
+			// set the org field to value from config
+			err = ctx.Set(internal.FlagOrg, config.Org)
+			if err != nil {
+				return err
+			}
+
+			continue
+		}
+
+		// check if the repo flag is available
+		// and if it is set in the context
+		if strings.Contains(f, internal.FlagRepo) &&
+			!ctx.IsSet(internal.FlagRepo) &&
+			len(config.Repo) > 0 {
+			// set the repo field to value from config
+			err = ctx.Set(internal.FlagRepo, config.Repo)
+			if err != nil {
+				return err
+			}
+
+			continue
+		}
+
+		// check if the secret engine flag is available
+		// and if it is set in the context
+		if strings.Contains(f, internal.FlagSecretEngine) &&
+			!ctx.IsSet(internal.FlagSecretEngine) &&
+			len(config.Secret.Engine) > 0 {
+			// set the secret engine field to value from config
+			err = ctx.Set(internal.FlagSecretEngine, config.Secret.Engine)
+			if err != nil {
+				return err
+			}
+
+			continue
+		}
+
+		// check if the secret type flag is available
+		// and if it is set in the context
+		if strings.Contains(f, internal.FlagSecretType) &&
+			!ctx.IsSet(internal.FlagSecretType) &&
+			len(config.Secret.Type) > 0 {
+			// set the secret type field to value from config
+			err = ctx.Set(internal.FlagSecretType, config.Secret.Type)
+			if err != nil {
+				return err
+			}
+
+			continue
 		}
 	}
 

--- a/action/config/load_test.go
+++ b/action/config/load_test.go
@@ -14,7 +14,25 @@ import (
 )
 
 func TestConfig_Config_Load(t *testing.T) {
+	// setup app
+	app := cli.NewApp()
+	app.Flags = []cli.Flag{
+		&cli.StringFlag{Name: "config"},
+		&cli.StringFlag{Name: "api.addr"},
+		&cli.StringFlag{Name: "api.token"},
+		&cli.StringFlag{Name: "api.version"},
+		&cli.StringFlag{Name: "log.level"},
+		&cli.StringFlag{Name: "output"},
+		&cli.StringFlag{Name: "org"},
+		&cli.StringFlag{Name: "repo"},
+		&cli.StringFlag{Name: "secret.engine"},
+		&cli.StringFlag{Name: "secret.type"},
+	}
+
 	// setup flags
+	configSet := flag.NewFlagSet("test", 0)
+	configSet.Parse([]string{"view", "config"})
+
 	fullSet := flag.NewFlagSet("test", 0)
 	fullSet.String("api.addr", "https://vela-server.localhost", "doc")
 	fullSet.String("api.token", "superSecretToken", "doc")
@@ -38,6 +56,14 @@ func TestConfig_Config_Load(t *testing.T) {
 				Action: "load",
 				File:   "testdata/config.yml",
 			},
+			set: configSet,
+		},
+		{
+			failure: false,
+			config: &Config{
+				Action: "load",
+				File:   "testdata/config.yml",
+			},
 			set: fullSet,
 		},
 		{
@@ -53,7 +79,7 @@ func TestConfig_Config_Load(t *testing.T) {
 	// run tests
 	for _, test := range tests {
 		// setup context
-		ctx := cli.NewContext(nil, test.set, nil)
+		ctx := cli.NewContext(app, test.set, nil)
 
 		// setup filesystem
 		appFS = afero.NewMemMapFs()

--- a/cmd/vela-cli/load.go
+++ b/cmd/vela-cli/load.go
@@ -5,6 +5,7 @@
 package main
 
 import (
+	"github.com/go-vela/cli/action/config"
 	"github.com/go-vela/cli/internal"
 
 	"github.com/sirupsen/logrus"
@@ -12,8 +13,8 @@ import (
 	"github.com/urfave/cli/v2"
 )
 
-// setLogging is a helper function that sets up logging for the CLI.
-func setLogging(c *cli.Context) error {
+// load is a helper function that loads the necessary configuration for the CLI.
+func load(c *cli.Context) error {
 	// set log level for the CLI
 	switch c.String(internal.FlagLogLevel) {
 	case "t", "trace", "Trace", "TRACE":
@@ -32,6 +33,28 @@ func setLogging(c *cli.Context) error {
 		fallthrough
 	default:
 		logrus.SetLevel(logrus.InfoLevel)
+	}
+
+	// create the config file configuration
+	//
+	// https://pkg.go.dev/github.com/go-vela/cli/action/config?tab=doc#Config
+	conf := &config.Config{
+		Action: "load",
+		File:   c.String(internal.FlagConfig),
+	}
+
+	// validate config file configuration
+	//
+	// https://pkg.go.dev/github.com/go-vela/cli/action/config?tab=doc#Config.Validate
+	err := conf.Validate()
+	if err == nil {
+		// execute the load call for the config file configuration
+		//
+		// https://pkg.go.dev/github.com/go-vela/cli/action/config?tab=doc#Config.Load
+		err = conf.Load(c)
+		if err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/cmd/vela-cli/main.go
+++ b/cmd/vela-cli/main.go
@@ -36,7 +36,7 @@ func main() {
 
 	// CLI Metadata
 
-	app.Before = setLogging
+	app.Before = load
 	app.Compiled = time.Now()
 	app.EnableBashCompletion = true
 	app.UseShortOptionHandling = true


### PR DESCRIPTION
## Description

Based off internal team feedback and discussions.

The tl;dr is the way were trying to load the flags in the config file often lead to:

```sh
FATA[0000] no such flag -<flag_name>
```

## Context

This PR will now add extra logic to accomplish a few different things:

1. Skip loading the configuration file if `config` is provided as an argument to the CLI

* i.e. `vela generate config`, `vela update config`, `vela view config` etc

2. Load values from the configuration file only if they're present in the existing context

As an example, you're allowed to configure an `org` and `repo` in the configuration file:

```yaml
api:
  addr: https://vela-server.localhost.com
  token: someSuperSecureToken
org: MyOrg
repo: MyRepo
```

The problem is that not all commands will require those flags or have them defined. This leads to errors provided when executing commands:

```sh
$ vela view config
FATA[0000] no such flag -org
```

The `go-vela/cli/action/config.Load()` has now been augmented to take the current command being executed into account.

This allows us to:

* lookup the current subcommand being ran from the context
* iterate through all the flags available for that subcommand
* for each flag in the subcommand we then:
    * check if the subcommand flag is set in the config file
    * if the subcommand flag is set in the config file, we then overwrite the subcommand flag with the value from the config
    * if the subcommand flag is not set in the config file, we continue processing to the next subcommand flag