### PR TITLE
fix: ensure log data is outputted in string format

### DIFF
--- a/action/log/view.go
+++ b/action/log/view.go
@@ -52,7 +52,7 @@ func (c *Config) ViewService(client *vela.Client) error {
 		// output the service log in stdout format
 		//
 		// https://pkg.go.dev/github.com/go-vela/cli/internal/output?tab=doc#Stdout
-		return output.Stdout(log)
+		return output.Stdout(string(log.GetData()))
 	}
 }
 
@@ -96,6 +96,6 @@ func (c *Config) ViewStep(client *vela.Client) error {
 		// output the step log in stdout format
 		//
 		// https://pkg.go.dev/github.com/go-vela/cli/internal/output?tab=doc#Stdout
-		return output.Stdout(log)
+		return output.Stdout(string(log.GetData()))
 	}
 }

--- a/version/version.go
+++ b/version/version.go
@@ -12,7 +12,7 @@ var (
 	// VersionMinor is for functionality in a backwards-compatible manner
 	VersionMinor int64 = 5
 	// VersionPatch is for backwards-compatible bug fixes
-	VersionPatch int64
+	VersionPatch int64 = 2
 )
 
 // Version is the specification version that the package types support.


### PR DESCRIPTION
This PR will ensure that we see the log data in string format rather than a byte array 👍 

## Old

```sh
$ vela get logs --org JordanBrockopp --repo vela-play --build 161
&[{0xc000328220 0xc000328240 0xc000328250 ...}]
```

## New

```sh
$ vela get logs --org JordanBrockopp --repo vela-play --build 161
> Inspecting runtime network...
$ docker network inspect JordanBrockopp_vela-play_161
{
...
```