### PR TITLE
refactor: make yaml output default for some view subcommands

### DIFF
--- a/action/build_view.go
+++ b/action/build_view.go
@@ -53,6 +53,7 @@ var BuildView = &cli.Command{
 			Name:    internal.FlagOutput,
 			Aliases: []string{"op"},
 			Usage:   "format the output in json, spew or yaml",
+			Value:   "yaml",
 		},
 	},
 	CustomHelpTemplate: fmt.Sprintf(`%s

--- a/action/deployment_view.go
+++ b/action/deployment_view.go
@@ -53,6 +53,7 @@ var DeploymentView = &cli.Command{
 			Name:    internal.FlagOutput,
 			Aliases: []string{"op"},
 			Usage:   "format the output in json, spew or yaml",
+			Value:   "yaml",
 		},
 	},
 	CustomHelpTemplate: fmt.Sprintf(`%s

--- a/action/hook_view.go
+++ b/action/hook_view.go
@@ -53,6 +53,7 @@ var HookView = &cli.Command{
 			Name:    internal.FlagOutput,
 			Aliases: []string{"op"},
 			Usage:   "format the output in json, spew or yaml",
+			Value:   "yaml",
 		},
 	},
 	CustomHelpTemplate: fmt.Sprintf(`%s

--- a/action/repo_view.go
+++ b/action/repo_view.go
@@ -44,6 +44,7 @@ var RepoView = &cli.Command{
 			Name:    internal.FlagOutput,
 			Aliases: []string{"op"},
 			Usage:   "format the output in json, spew or yaml",
+			Value:   "yaml",
 		},
 	},
 	CustomHelpTemplate: fmt.Sprintf(`%s

--- a/action/secret_get.go
+++ b/action/secret_get.go
@@ -19,6 +19,7 @@ import (
 // SecretGet defines the command for inspecting a secret.
 var SecretGet = &cli.Command{
 	Name:        "secret",
+	Aliases:     []string{"secrets"},
 	Description: "Use this command to get a list of secrets.",
 	Usage:       "Display a list of secrets",
 	Action:      secretGet,

--- a/action/service_view.go
+++ b/action/service_view.go
@@ -62,6 +62,7 @@ var ServiceView = &cli.Command{
 			Name:    internal.FlagOutput,
 			Aliases: []string{"op"},
 			Usage:   "format the output in json, spew or yaml",
+			Value:   "yaml",
 		},
 	},
 	CustomHelpTemplate: fmt.Sprintf(`%s

--- a/action/step_view.go
+++ b/action/step_view.go
@@ -62,6 +62,7 @@ var StepView = &cli.Command{
 			Name:    internal.FlagOutput,
 			Aliases: []string{"op"},
 			Usage:   "format the output in json, spew or yaml",
+			Value:   "yaml",
 		},
 	},
 	CustomHelpTemplate: fmt.Sprintf(`%s


### PR DESCRIPTION
This PR will make `yaml` be the default output for the `view` subcommand on certain resources.

Currently, this impacts the following commands:

* `vela view build`
* `vela view deployment`
* `vela view hook`
* `vela view service`
* `vela view step`

The following commands will not be impacted:

* `vela view log`
* `vela view secret`