### PR TITLE
fix: remove -h alias due to conflict with help

### DIFF
--- a/action/hook_view.go
+++ b/action/hook_view.go
@@ -42,7 +42,6 @@ var HookView = &cli.Command{
 		&cli.IntFlag{
 			EnvVars: []string{"VELA_HOOK", "HOOK_NUMBER"},
 			Name:    "hook",
-			Aliases: []string{"h"},
 			Usage:   "provide the number for the hook",
 		},
 


### PR DESCRIPTION
This removes the `-h` alias for the `--hook` flag when running the `vela view hook` subcommand.

Currently if you attempt to run that command you're met with a panic and stack trace (provided below).

This is caused by the `--help` and `-h` flags automatically appended to every command/subcommand by the CLI library we're using.

```sh
$ vela view hook --help                                                                                                                                                                                                       07:43:54 AM with Z0027PD at C02ZW5Y3MD6R •100%
hook flag redefined: h
panic: hook flag redefined: h

goroutine 1 [running]:
flag.(*FlagSet).Var(0xc00012d320, 0x171c980, 0xc000229241, 0x1a11500, 0x1, 0x16685ca, 0x9)
	/usr/local/go/src/flag/flag.go:851 +0x485
flag.(*FlagSet).BoolVar(...)
	/usr/local/go/src/flag/flag.go:624
flag.(*FlagSet).Bool(0xc00012d320, 0x1a11500, 0x1, 0x0, 0x16685ca, 0x9, 0xc000229240)
	/usr/local/go/src/flag/flag.go:637 +0x8a
```