### PR TITLE
fix(args): switch from BoolFlag to StringFlag to reduce confusion

### DIFF
--- a/action/completion_generate.go
+++ b/action/completion_generate.go
@@ -22,13 +22,13 @@ var CompletionGenerate = &cli.Command{
 
 		// Shell Flags
 
-		&cli.BoolFlag{
+		&cli.StringFlag{
 			EnvVars: []string{"VELA_BASH", "COMPLETION_BASH"},
 			Name:    "bash",
 			Aliases: []string{"b"},
 			Usage:   "generate a bash auto completion script",
 		},
-		&cli.BoolFlag{
+		&cli.StringFlag{
 			EnvVars: []string{"VELA_ZSH", "COMPLETION_ZSH"},
 			Name:    "zsh",
 			Aliases: []string{"z"},

--- a/action/completion_generate.go
+++ b/action/completion_generate.go
@@ -40,9 +40,9 @@ var CompletionGenerate = &cli.Command{
 	CustomHelpTemplate: fmt.Sprintf(`%s
 EXAMPLES:
   1. Enable auto completion for the current bash session.
-    $ source <({{.HelpName}} --bash)
+    $ source <({{.HelpName}} --bash true)
   2. Enable auto completion for the current zsh session.
-    $ source <({{.HelpName}} --zsh)
+    $ source <({{.HelpName}} --zsh true)
   3. Enable auto completion for bash permanently.
     visit https://go-vela.github.io/docs/cli/completion/generate/#bash
   4. Enable auto completion for zsh permanently.

--- a/action/completion_generate.go
+++ b/action/completion_generate.go
@@ -27,12 +27,14 @@ var CompletionGenerate = &cli.Command{
 			Name:    "bash",
 			Aliases: []string{"b"},
 			Usage:   "generate a bash auto completion script",
+			Value:   "false",
 		},
 		&cli.StringFlag{
 			EnvVars: []string{"VELA_ZSH", "COMPLETION_ZSH"},
 			Name:    "zsh",
 			Aliases: []string{"z"},
 			Usage:   "generate a zsh auto completion script",
+			Value:   "false",
 		},
 	},
 	CustomHelpTemplate: fmt.Sprintf(`%s

--- a/action/config_remove.go
+++ b/action/config_remove.go
@@ -28,18 +28,21 @@ var ConfigRemove = &cli.Command{
 			Name:    internal.FlagAPIAddress,
 			Aliases: []string{"a"},
 			Usage:   "removes the API addr from the config file",
+			Value:   "false",
 		},
 		&cli.StringFlag{
 			EnvVars: []string{"VELA_TOKEN", "CONFIG_TOKEN"},
 			Name:    internal.FlagAPIToken,
 			Aliases: []string{"t"},
 			Usage:   "removes the API token from the config file",
+			Value:   "false",
 		},
 		&cli.StringFlag{
 			EnvVars: []string{"VELA_API_VERSION", "CONFIG_API_VERSION"},
 			Name:    internal.FlagAPIVersion,
 			Aliases: []string{"av"},
 			Usage:   "removes the API version from the config file",
+			Value:   "false",
 		},
 
 		// Log Flags
@@ -49,6 +52,7 @@ var ConfigRemove = &cli.Command{
 			Name:    internal.FlagLogLevel,
 			Aliases: []string{"l"},
 			Usage:   "removes the log level from the config file",
+			Value:   "false",
 		},
 
 		// Output Flags
@@ -58,6 +62,7 @@ var ConfigRemove = &cli.Command{
 			Name:    internal.FlagOutput,
 			Aliases: []string{"op"},
 			Usage:   "removes the output from the config file",
+			Value:   "false",
 		},
 
 		// Repo Flags
@@ -67,12 +72,14 @@ var ConfigRemove = &cli.Command{
 			Name:    internal.FlagOrg,
 			Aliases: []string{"o"},
 			Usage:   "removes the org from the config file",
+			Value:   "false",
 		},
 		&cli.StringFlag{
 			EnvVars: []string{"VELA_REPO", "CONFIG_REPO"},
 			Name:    internal.FlagRepo,
 			Aliases: []string{"r"},
 			Usage:   "removes the repo from the config file",
+			Value:   "false",
 		},
 
 		// Secret Flags
@@ -82,12 +89,14 @@ var ConfigRemove = &cli.Command{
 			Name:    internal.FlagSecretEngine,
 			Aliases: []string{"e"},
 			Usage:   "removes the secret engine from the config file",
+			Value:   "false",
 		},
 		&cli.StringFlag{
 			EnvVars: []string{"VELA_TYPE", "CONFIG_TYPE"},
 			Name:    internal.FlagSecretType,
 			Aliases: []string{"ty"},
 			Usage:   "removes the secret type from the config file",
+			Value:   "false",
 		},
 	},
 	CustomHelpTemplate: fmt.Sprintf(`%s

--- a/action/config_remove.go
+++ b/action/config_remove.go
@@ -23,19 +23,19 @@ var ConfigRemove = &cli.Command{
 
 		// API Flags
 
-		&cli.BoolFlag{
+		&cli.StringFlag{
 			EnvVars: []string{"VELA_ADDR", "CONFIG_ADDR"},
 			Name:    internal.FlagAPIAddress,
 			Aliases: []string{"a"},
 			Usage:   "removes the API addr from the config file",
 		},
-		&cli.BoolFlag{
+		&cli.StringFlag{
 			EnvVars: []string{"VELA_TOKEN", "CONFIG_TOKEN"},
 			Name:    internal.FlagAPIToken,
 			Aliases: []string{"t"},
 			Usage:   "removes the API token from the config file",
 		},
-		&cli.BoolFlag{
+		&cli.StringFlag{
 			EnvVars: []string{"VELA_API_VERSION", "CONFIG_API_VERSION"},
 			Name:    internal.FlagAPIVersion,
 			Aliases: []string{"av"},
@@ -44,7 +44,7 @@ var ConfigRemove = &cli.Command{
 
 		// Log Flags
 
-		&cli.BoolFlag{
+		&cli.StringFlag{
 			EnvVars: []string{"VELA_LOG_LEVEL", "CONFIG_LOG_LEVEL"},
 			Name:    internal.FlagLogLevel,
 			Aliases: []string{"l"},
@@ -53,7 +53,7 @@ var ConfigRemove = &cli.Command{
 
 		// Output Flags
 
-		&cli.BoolFlag{
+		&cli.StringFlag{
 			EnvVars: []string{"VELA_OUTPUT", "CONFIG_OUTPUT"},
 			Name:    internal.FlagOutput,
 			Aliases: []string{"op"},
@@ -62,13 +62,13 @@ var ConfigRemove = &cli.Command{
 
 		// Repo Flags
 
-		&cli.BoolFlag{
+		&cli.StringFlag{
 			EnvVars: []string{"VELA_ORG", "CONFIG_ORG"},
 			Name:    internal.FlagOrg,
 			Aliases: []string{"o"},
 			Usage:   "removes the org from the config file",
 		},
-		&cli.BoolFlag{
+		&cli.StringFlag{
 			EnvVars: []string{"VELA_REPO", "CONFIG_REPO"},
 			Name:    internal.FlagRepo,
 			Aliases: []string{"r"},
@@ -77,13 +77,13 @@ var ConfigRemove = &cli.Command{
 
 		// Secret Flags
 
-		&cli.BoolFlag{
+		&cli.StringFlag{
 			EnvVars: []string{"VELA_ENGINE", "CONFIG_ENGINE"},
 			Name:    internal.FlagSecretEngine,
 			Aliases: []string{"e"},
 			Usage:   "removes the secret engine from the config file",
 		},
-		&cli.BoolFlag{
+		&cli.StringFlag{
 			EnvVars: []string{"VELA_TYPE", "CONFIG_TYPE"},
 			Name:    internal.FlagSecretType,
 			Aliases: []string{"ty"},

--- a/action/config_remove.go
+++ b/action/config_remove.go
@@ -104,13 +104,13 @@ EXAMPLES:
   1. Remove the config file.
     $ {{.HelpName}}
   2. Remove the addr field from the config file.
-    $ {{.HelpName}} --api.addr
+    $ {{.HelpName}} --api.addr true
   3. Remove the token field from the config file.
-    $ {{.HelpName}} --api.token
+    $ {{.HelpName}} --api.token true
   4. Remove the secret engine and type fields from the config file.
-    $ {{.HelpName}} --secret.engine --secret.type
+    $ {{.HelpName}} --secret.engine true --secret.type true
   5. Remove the log level field from the config file.
-    $ {{.HelpName}} --log.level
+    $ {{.HelpName}} --log.level true
 
 DOCUMENTATION:
 

--- a/action/pipeline_generate.go
+++ b/action/pipeline_generate.go
@@ -40,6 +40,7 @@ var PipelineGenerate = &cli.Command{
 			Name:    "stages",
 			Aliases: []string{"s"},
 			Usage:   "enable generating the pipeline with stages",
+			Value:   "false",
 		},
 		&cli.StringFlag{
 			EnvVars: []string{"VELA_TYPE", "PIPELINE_TYPE"},

--- a/action/pipeline_generate.go
+++ b/action/pipeline_generate.go
@@ -58,7 +58,7 @@ EXAMPLES:
   3. Generate a Vela pipeline in a specific directory.
     $ {{.HelpName}} --path /absolute/full/path/to/dir
   4. Generate a Vela pipeline with stages.
-    $ {{.HelpName}} --stages
+    $ {{.HelpName}} --stages true
   5. Generate a go Vela pipeline.
     $ {{.HelpName}} --secret.type go
   6. Generate a java Vela pipeline.

--- a/action/pipeline_generate.go
+++ b/action/pipeline_generate.go
@@ -35,7 +35,7 @@ var PipelineGenerate = &cli.Command{
 			Aliases: []string{"p"},
 			Usage:   "provide the path to the file for the pipeline",
 		},
-		&cli.BoolFlag{
+		&cli.StringFlag{
 			EnvVars: []string{"VELA_STAGES", "PIPELINE_STAGES"},
 			Name:    "stages",
 			Aliases: []string{"s"},

--- a/action/repo_add.go
+++ b/action/repo_add.go
@@ -71,19 +71,19 @@ var RepoAdd = &cli.Command{
 			Usage:   "max time allowed per build in repository",
 			Value:   30,
 		},
-		&cli.BoolFlag{
+		&cli.StringFlag{
 			EnvVars: []string{"VELA_PRIVATE", "REPO_PRIVATE"},
 			Name:    "private",
 			Aliases: []string{"p"},
 			Usage:   "disable public access to the repository",
 		},
-		&cli.BoolFlag{
+		&cli.StringFlag{
 			EnvVars: []string{"VELA_TRUSTED", "REPO_TRUSTED"},
 			Name:    "trusted",
 			Aliases: []string{"tr"},
 			Usage:   "elevated permissions for builds executed for repo",
 		},
-		&cli.BoolFlag{
+		&cli.StringFlag{
 			EnvVars: []string{"VELA_ACTIVE", "REPO_ACTIVE"},
 			Name:    "active",
 			Aliases: []string{"a"},

--- a/action/repo_add.go
+++ b/action/repo_add.go
@@ -76,18 +76,21 @@ var RepoAdd = &cli.Command{
 			Name:    "private",
 			Aliases: []string{"p"},
 			Usage:   "disable public access to the repository",
+			Value:   "false",
 		},
 		&cli.StringFlag{
 			EnvVars: []string{"VELA_TRUSTED", "REPO_TRUSTED"},
 			Name:    "trusted",
 			Aliases: []string{"tr"},
 			Usage:   "elevated permissions for builds executed for repo",
+			Value:   "false",
 		},
 		&cli.StringFlag{
 			EnvVars: []string{"VELA_ACTIVE", "REPO_ACTIVE"},
 			Name:    "active",
 			Aliases: []string{"a"},
 			Usage:   "current status of the repository",
+			Value:   "false",
 		},
 		&cli.StringSliceFlag{
 			EnvVars: []string{"VELA_EVENTS", "REPO_EVENTS"},

--- a/action/repo_update.go
+++ b/action/repo_update.go
@@ -71,19 +71,19 @@ var RepoUpdate = &cli.Command{
 			Usage:   "max time allowed per build in repository",
 			Value:   30,
 		},
-		&cli.BoolFlag{
+		&cli.StringFlag{
 			EnvVars: []string{"VELA_PRIVATE", "REPO_PRIVATE"},
 			Name:    "private",
 			Aliases: []string{"p"},
 			Usage:   "disable public access to the repository",
 		},
-		&cli.BoolFlag{
+		&cli.StringFlag{
 			EnvVars: []string{"VELA_TRUSTED", "REPO_TRUSTED"},
 			Name:    "trusted",
 			Aliases: []string{"tr"},
 			Usage:   "elevated permissions for builds executed for repo",
 		},
-		&cli.BoolFlag{
+		&cli.StringFlag{
 			EnvVars: []string{"VELA_ACTIVE", "REPO_ACTIVE"},
 			Name:    "active",
 			Aliases: []string{"a"},

--- a/action/repo_update.go
+++ b/action/repo_update.go
@@ -76,18 +76,21 @@ var RepoUpdate = &cli.Command{
 			Name:    "private",
 			Aliases: []string{"p"},
 			Usage:   "disable public access to the repository",
+			Value:   "false",
 		},
 		&cli.StringFlag{
 			EnvVars: []string{"VELA_TRUSTED", "REPO_TRUSTED"},
 			Name:    "trusted",
 			Aliases: []string{"tr"},
 			Usage:   "elevated permissions for builds executed for repo",
+			Value:   "false",
 		},
 		&cli.StringFlag{
 			EnvVars: []string{"VELA_ACTIVE", "REPO_ACTIVE"},
 			Name:    "active",
 			Aliases: []string{"a"},
 			Usage:   "current status of the repository",
+			Value:   "false",
 		},
 		&cli.StringSliceFlag{
 			EnvVars: []string{"VELA_EVENTS", "REPO_EVENTS"},

--- a/action/secret_add.go
+++ b/action/secret_add.go
@@ -90,12 +90,12 @@ var SecretAdd = &cli.Command{
 				constants.EventTag,
 			),
 		},
-		&cli.BoolFlag{
+		&cli.StringFlag{
 			EnvVars: []string{"VELA_COMMAND", "SECRET_COMMAND"},
 			Name:    "commands",
 			Aliases: []string{"c"},
 			Usage:   "enable a secret to be used for a step with commands",
-			Value:   true,
+			Value:   "true",
 		},
 		&cli.StringFlag{
 			EnvVars: []string{"VELA_FILE", "SECRET_FILE"},

--- a/action/secret_update.go
+++ b/action/secret_update.go
@@ -90,12 +90,12 @@ var SecretUpdate = &cli.Command{
 				constants.EventTag,
 			),
 		},
-		&cli.BoolFlag{
+		&cli.StringFlag{
 			EnvVars: []string{"VELA_COMMAND", "SECRET_COMMAND"},
 			Name:    "commands",
 			Aliases: []string{"c"},
 			Usage:   "enable a secret to be used for a step with commands",
-			Value:   true,
+			Value:   "true",
 		},
 		&cli.StringFlag{
 			EnvVars: []string{"VELA_FILE", "SECRET_FILE"},


### PR DESCRIPTION
When `cli.BoolFlag` has the default value of `true` you are unable to override it, so the next best option is to switch to `cli.StringFlag` and still use the `c.Bool("commands")` to parse whether it is true or false.

A simple program to validate what I'm saying is true:

```golang
package main

import (
	"fmt"
	"log"
	"os"

	"github.com/urfave/cli/v2"
)

func main() {
	app := &cli.App{
		Flags: []cli.Flag{
			&cli.BoolFlag{
				EnvVars: []string{"VELA_COMMAND", "SECRET_COMMAND"},
				Name:    "commands",
				Aliases: []string{"c"},
				Usage:   "enable a secret to be used for a step with commands",
				Value:   true,
			},
		},
	}
	app.Action = run

	err := app.Run(os.Args)
	if err != nil {
		log.Fatal(err)
	}
}

func run(c *cli.Context) error {
	fmt.Println("commands", c.Bool("commands"))

	err := exec()
	return err
}

func exec() error {
	return nil
}
```

Note that I've also identified some issues within the server that need to be fixed in relation to `allow_commands` not getting set properly. 