### PR TITLE
refactor: update default active flag to true

### DIFF
--- a/action/repo_add.go
+++ b/action/repo_add.go
@@ -90,7 +90,7 @@ var RepoAdd = &cli.Command{
 			Name:    "active",
 			Aliases: []string{"a"},
 			Usage:   "current status of the repository",
-			Value:   "false",
+			Value:   "true",
 		},
 		&cli.StringSliceFlag{
 			EnvVars: []string{"VELA_EVENTS", "REPO_EVENTS"},

--- a/action/repo_update.go
+++ b/action/repo_update.go
@@ -90,7 +90,7 @@ var RepoUpdate = &cli.Command{
 			Name:    "active",
 			Aliases: []string{"a"},
 			Usage:   "current status of the repository",
-			Value:   "false",
+			Value:   "true",
 		},
 		&cli.StringSliceFlag{
 			EnvVars: []string{"VELA_EVENTS", "REPO_EVENTS"},


### PR DESCRIPTION
See https://github.com/go-vela/cli/pull/162 for more information.

This PR updates the `active` flag to have a default value of `true` 👍 

This change is made for the following subcommands:

* `vela add repo`
* `vela update repo`