### PR TITLE
fix: check if arg equals config

### DIFF
--- a/action/config/load.go
+++ b/action/config/load.go
@@ -27,7 +27,7 @@ func (c *Config) Load(ctx *cli.Context) error {
 		// check if we're operating on the config resource
 		//
 		// nolint:lll // log message is too long
-		if strings.Contains(arg, "config") {
+		if strings.EqualFold(arg, "config") {
 			logrus.Debugf("config arg provided in %v - skipping load for config file %s", ctx.Args().Slice(), c.File)
 
 			return nil


### PR DESCRIPTION
Currently, if you have an `org` or `repo` with `config` in the name, it'll lead to weird issues when running CLI commands.

Example:

```sh
$ vela view build --org sampleOrg --repo sampleRepo-configs --build 1
FATA[0000] no client address provided
```

Running the CLI with `trace` level logging provides some insight into the issue:

```sh
$ VELA_LOG_LEVEL=trace vela view build --org sampleOrg --repo sampleRepo-configs --build 1
DEBU[0000] validating config file configuration
DEBU[0000] executing load for config file configuration
DEBU[0000] config arg provided in [view build --org sampleOrg --repo sampleRepo-configs --build 1] - skipping load for config file $HOME/.vela/config.yml
DEBU[0000] validating config file configuration
DEBU[0000] executing load for config file configuration
DEBU[0000] checking if config file is empty
TRAC[0000] checking if API values in config file are empty
DEBU[0000] parsing Vela client from provided configuration
DEBU[0000] validating provided configuration for Vela client
FATA[0000] no client address provided
```

This PR resolves the issue by switching the method we check for the `config` argument.

Instead of using `strings.Contains()` which would unintentionally trigger the check because of the repo name `sampleRepo-configs`, we now use `strings.EqualFold()` which should only pick up a direct match to `config` 👍 