### PR TITLE
feat: add new compile/expand pipeline commands

### DIFF
--- a/action/action.go
+++ b/action/action.go
@@ -12,6 +12,12 @@ const (
 	// chownAction defines the action for changing ownership of a resource.
 	chownAction = "chown"
 
+	// compileAction defines the action for compiling a resource.
+	compileAction = "compile"
+
+	// expandAction defines the action for expanding a resource.
+	expandAction = "expand"
+
 	// generateAction defines the action for producing a resource.
 	generateAction = "generate"
 

--- a/action/pipeline_compile.go
+++ b/action/pipeline_compile.go
@@ -1,0 +1,115 @@
+// Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+//
+// Use of this source code is governed by the LICENSE file in this repository.
+
+package action
+
+import (
+	"fmt"
+
+	"github.com/go-vela/cli/action/pipeline"
+	"github.com/go-vela/cli/internal"
+	"github.com/go-vela/cli/internal/client"
+
+	"github.com/urfave/cli/v2"
+)
+
+// PipelineCompile defines the command for compiling a pipeline.
+var PipelineCompile = &cli.Command{
+	Name:        "pipeline",
+	Description: "Use this command to compile a pipeline.",
+	Usage:       "Compile the provided pipeline",
+	Action:      pipelineCompile,
+	Flags: []cli.Flag{
+
+		// Repo Flags
+
+		&cli.StringFlag{
+			EnvVars: []string{"VELA_ORG", "REPO_ORG"},
+			Name:    internal.FlagOrg,
+			Aliases: []string{"o"},
+			Usage:   "provide the organization for the pipeline",
+		},
+		&cli.StringFlag{
+			EnvVars: []string{"VELA_REPO", "REPO_NAME"},
+			Name:    internal.FlagRepo,
+			Aliases: []string{"r"},
+			Usage:   "provide the repository for the pipeline",
+		},
+
+		// Output Flags
+
+		&cli.StringFlag{
+			EnvVars: []string{"VELA_OUTPUT", "REPO_OUTPUT"},
+			Name:    internal.FlagOutput,
+			Aliases: []string{"op"},
+			Usage:   "format the output in json, spew or yaml",
+			Value:   "yaml",
+		},
+
+		// Pipeline Flags
+
+		&cli.StringFlag{
+			EnvVars: []string{"VELA_REF", "PIPELINE_REF"},
+			Name:    "ref",
+			Usage:   "provide the repository reference for the pipeline",
+			Value:   "master",
+		},
+	},
+	CustomHelpTemplate: fmt.Sprintf(`%s
+EXAMPLES:
+  1. Compile a pipeline for a repository.
+    $ {{.HelpName}} --org MyOrg --repo MyRepo
+  2. Compile a pipeline for a repository with json output.
+    $ {{.HelpName}} --org MyOrg --repo MyRepo --output json
+  3. Compile a pipeline for a repository when config or environment variables are set.
+    $ {{.HelpName}}
+
+DOCUMENTATION:
+
+  https://go-vela.github.io/docs/cli/pipeline/compile/
+`, cli.CommandHelpTemplate),
+}
+
+// helper function to capture the provided
+// input and create the object used to
+// compile a pipeline.
+func pipelineCompile(c *cli.Context) error {
+	// load variables from the config file
+	err := load(c)
+	if err != nil {
+		return err
+	}
+
+	// parse the Vela client from the context
+	//
+	// https://pkg.go.dev/github.com/go-vela/cli/internal/client?tab=doc#Parse
+	client, err := client.Parse(c)
+	if err != nil {
+		return err
+	}
+
+	// create the pipeline configuration
+	//
+	// https://pkg.go.dev/github.com/go-vela/cli/action/pipeline?tab=doc#Config
+	p := &pipeline.Config{
+		Action: compileAction,
+		Org:    c.String(internal.FlagOrg),
+		Repo:   c.String(internal.FlagRepo),
+		Output: c.String(internal.FlagOutput),
+		Ref:    c.String("ref"),
+	}
+
+	// validate pipeline configuration
+	//
+	// https://pkg.go.dev/github.com/go-vela/cli/action/pipeline?tab=doc#Config.Validate
+	err = p.Validate()
+	if err != nil {
+		return err
+	}
+
+	// execute the compile call for the pipeline configuration
+	//
+	// https://pkg.go.dev/github.com/go-vela/cli/action/pipeline?tab=doc#Config.Compile
+	return p.Compile(client)
+}

--- a/action/pipeline_compile_test.go
+++ b/action/pipeline_compile_test.go
@@ -10,10 +10,11 @@ import (
 	"testing"
 
 	"github.com/go-vela/mock/server"
+
 	"github.com/urfave/cli/v2"
 )
 
-func TestAction_PipelineValidate(t *testing.T) {
+func TestAction_PipelineCompile(t *testing.T) {
 	// setup test server
 	s := httptest.NewServer(server.FakeHandler())
 
@@ -29,11 +30,6 @@ func TestAction_PipelineValidate(t *testing.T) {
 	fullSet.String("repo", "octocat", "doc")
 	fullSet.String("output", "json", "doc")
 
-	// setup flags
-	localSet := flag.NewFlagSet("test", 0)
-	localSet.String("file", "generate.yml", "doc")
-	localSet.String("path", "pipeline/testdata", "doc")
-
 	// setup tests
 	tests := []struct {
 		failure bool
@@ -42,10 +38,6 @@ func TestAction_PipelineValidate(t *testing.T) {
 		{
 			failure: false,
 			set:     fullSet,
-		},
-		{
-			failure: false,
-			set:     localSet,
 		},
 		{
 			failure: true,
@@ -59,18 +51,18 @@ func TestAction_PipelineValidate(t *testing.T) {
 
 	// run tests
 	for _, test := range tests {
-		err := pipelineValidate(cli.NewContext(nil, test.set, nil))
+		err := pipelineCompile(cli.NewContext(nil, test.set, nil))
 
 		if test.failure {
 			if err == nil {
-				t.Errorf("pipelineValidate should have returned err")
+				t.Errorf("pipelineCompile should have returned err")
 			}
 
 			continue
 		}
 
 		if err != nil {
-			t.Errorf("pipelineValidate returned err: %v", err)
+			t.Errorf("pipelineCompile returned err: %v", err)
 		}
 	}
 }

--- a/action/pipeline_expand.go
+++ b/action/pipeline_expand.go
@@ -1,0 +1,115 @@
+// Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+//
+// Use of this source code is governed by the LICENSE file in this repository.
+
+package action
+
+import (
+	"fmt"
+
+	"github.com/go-vela/cli/action/pipeline"
+	"github.com/go-vela/cli/internal"
+	"github.com/go-vela/cli/internal/client"
+
+	"github.com/urfave/cli/v2"
+)
+
+// PipelineExpand defines the command for expanding a pipeline.
+var PipelineExpand = &cli.Command{
+	Name:        "pipeline",
+	Description: "Use this command to expand a pipeline.",
+	Usage:       "Expand the provided pipeline",
+	Action:      pipelineExpand,
+	Flags: []cli.Flag{
+
+		// Repo Flags
+
+		&cli.StringFlag{
+			EnvVars: []string{"VELA_ORG", "REPO_ORG"},
+			Name:    internal.FlagOrg,
+			Aliases: []string{"o"},
+			Usage:   "provide the organization for the pipeline",
+		},
+		&cli.StringFlag{
+			EnvVars: []string{"VELA_REPO", "REPO_NAME"},
+			Name:    internal.FlagRepo,
+			Aliases: []string{"r"},
+			Usage:   "provide the repository for the pipeline",
+		},
+
+		// Output Flags
+
+		&cli.StringFlag{
+			EnvVars: []string{"VELA_OUTPUT", "REPO_OUTPUT"},
+			Name:    internal.FlagOutput,
+			Aliases: []string{"op"},
+			Usage:   "format the output in json, spew or yaml",
+			Value:   "yaml",
+		},
+
+		// Pipeline Flags
+
+		&cli.StringFlag{
+			EnvVars: []string{"VELA_REF", "PIPELINE_REF"},
+			Name:    "ref",
+			Usage:   "provide the repository reference for the pipeline",
+			Value:   "master",
+		},
+	},
+	CustomHelpTemplate: fmt.Sprintf(`%s
+EXAMPLES:
+  1. Expand a pipeline for a repository.
+    $ {{.HelpName}} --org MyOrg --repo MyRepo
+  2. Expand a pipeline for a repository with json output.
+    $ {{.HelpName}} --org MyOrg --repo MyRepo --output json
+  3. Expand a pipeline for a repository when config or environment variables are set.
+    $ {{.HelpName}}
+
+DOCUMENTATION:
+
+  https://go-vela.github.io/docs/cli/pipeline/expand/
+`, cli.CommandHelpTemplate),
+}
+
+// helper function to capture the provided
+// input and create the object used to
+// expand a pipeline.
+func pipelineExpand(c *cli.Context) error {
+	// load variables from the config file
+	err := load(c)
+	if err != nil {
+		return err
+	}
+
+	// parse the Vela client from the context
+	//
+	// https://pkg.go.dev/github.com/go-vela/cli/internal/client?tab=doc#Parse
+	client, err := client.Parse(c)
+	if err != nil {
+		return err
+	}
+
+	// create the pipeline configuration
+	//
+	// https://pkg.go.dev/github.com/go-vela/cli/action/pipeline?tab=doc#Config
+	p := &pipeline.Config{
+		Action: expandAction,
+		Org:    c.String(internal.FlagOrg),
+		Repo:   c.String(internal.FlagRepo),
+		Output: c.String(internal.FlagOutput),
+		Ref:    c.String("ref"),
+	}
+
+	// validate pipeline configuration
+	//
+	// https://pkg.go.dev/github.com/go-vela/cli/action/pipeline?tab=doc#Config.Validate
+	err = p.Validate()
+	if err != nil {
+		return err
+	}
+
+	// execute the expand call for the pipeline configuration
+	//
+	// https://pkg.go.dev/github.com/go-vela/cli/action/pipeline?tab=doc#Config.Expand
+	return p.Expand(client)
+}

--- a/action/pipeline_expand_test.go
+++ b/action/pipeline_expand_test.go
@@ -10,10 +10,11 @@ import (
 	"testing"
 
 	"github.com/go-vela/mock/server"
+
 	"github.com/urfave/cli/v2"
 )
 
-func TestAction_PipelineValidate(t *testing.T) {
+func TestAction_PipelineExpand(t *testing.T) {
 	// setup test server
 	s := httptest.NewServer(server.FakeHandler())
 
@@ -29,11 +30,6 @@ func TestAction_PipelineValidate(t *testing.T) {
 	fullSet.String("repo", "octocat", "doc")
 	fullSet.String("output", "json", "doc")
 
-	// setup flags
-	localSet := flag.NewFlagSet("test", 0)
-	localSet.String("file", "generate.yml", "doc")
-	localSet.String("path", "pipeline/testdata", "doc")
-
 	// setup tests
 	tests := []struct {
 		failure bool
@@ -42,10 +38,6 @@ func TestAction_PipelineValidate(t *testing.T) {
 		{
 			failure: false,
 			set:     fullSet,
-		},
-		{
-			failure: false,
-			set:     localSet,
 		},
 		{
 			failure: true,
@@ -59,18 +51,18 @@ func TestAction_PipelineValidate(t *testing.T) {
 
 	// run tests
 	for _, test := range tests {
-		err := pipelineValidate(cli.NewContext(nil, test.set, nil))
+		err := pipelineExpand(cli.NewContext(nil, test.set, nil))
 
 		if test.failure {
 			if err == nil {
-				t.Errorf("pipelineValidate should have returned err")
+				t.Errorf("pipelineExpand should have returned err")
 			}
 
 			continue
 		}
 
 		if err != nil {
-			t.Errorf("pipelineValidate returned err: %v", err)
+			t.Errorf("pipelineExpand returned err: %v", err)
 		}
 	}
 }

--- a/action/pipeline_view.go
+++ b/action/pipeline_view.go
@@ -1,0 +1,115 @@
+// Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+//
+// Use of this source code is governed by the LICENSE file in this repository.
+
+package action
+
+import (
+	"fmt"
+
+	"github.com/go-vela/cli/action/pipeline"
+	"github.com/go-vela/cli/internal"
+	"github.com/go-vela/cli/internal/client"
+
+	"github.com/urfave/cli/v2"
+)
+
+// PipelineView defines the command for inspecting a pipeline.
+var PipelineView = &cli.Command{
+	Name:        "pipeline",
+	Description: "Use this command to view a pipeline.",
+	Usage:       "View details of the provided pipeline",
+	Action:      pipelineView,
+	Flags: []cli.Flag{
+
+		// Repo Flags
+
+		&cli.StringFlag{
+			EnvVars: []string{"VELA_ORG", "REPO_ORG"},
+			Name:    internal.FlagOrg,
+			Aliases: []string{"o"},
+			Usage:   "provide the organization for the pipeline",
+		},
+		&cli.StringFlag{
+			EnvVars: []string{"VELA_REPO", "REPO_NAME"},
+			Name:    internal.FlagRepo,
+			Aliases: []string{"r"},
+			Usage:   "provide the repository for the pipeline",
+		},
+
+		// Output Flags
+
+		&cli.StringFlag{
+			EnvVars: []string{"VELA_OUTPUT", "REPO_OUTPUT"},
+			Name:    internal.FlagOutput,
+			Aliases: []string{"op"},
+			Usage:   "format the output in json, spew or yaml",
+			Value:   "yaml",
+		},
+
+		// Pipeline Flags
+
+		&cli.StringFlag{
+			EnvVars: []string{"VELA_REF", "PIPELINE_REF"},
+			Name:    "ref",
+			Usage:   "provide the repository reference for the pipeline",
+			Value:   "master",
+		},
+	},
+	CustomHelpTemplate: fmt.Sprintf(`%s
+EXAMPLES:
+  1. View details of a pipeline for a repository.
+    $ {{.HelpName}} --org MyOrg --repo MyRepo
+  2. View details of a pipeline for a repository with json output.
+    $ {{.HelpName}} --org MyOrg --repo MyRepo
+  3. View details of a pipeline for a repository when config or environment variables are set.
+    $ {{.HelpName}}
+
+DOCUMENTATION:
+
+  https://go-vela.github.io/docs/cli/pipeline/view/
+`, cli.CommandHelpTemplate),
+}
+
+// helper function to capture the provided
+// input and create the object used to
+// inspect a pipeline.
+func pipelineView(c *cli.Context) error {
+	// load variables from the config file
+	err := load(c)
+	if err != nil {
+		return err
+	}
+
+	// parse the Vela client from the context
+	//
+	// https://pkg.go.dev/github.com/go-vela/cli/internal/client?tab=doc#Parse
+	client, err := client.Parse(c)
+	if err != nil {
+		return err
+	}
+
+	// create the pipeline configuration
+	//
+	// https://pkg.go.dev/github.com/go-vela/cli/action/pipeline?tab=doc#Config
+	p := &pipeline.Config{
+		Action: viewAction,
+		Org:    c.String(internal.FlagOrg),
+		Repo:   c.String(internal.FlagRepo),
+		Output: c.String(internal.FlagOutput),
+		Ref:    c.String("ref"),
+	}
+
+	// validate pipeline configuration
+	//
+	// https://pkg.go.dev/github.com/go-vela/cli/action/pipeline?tab=doc#Config.Validate
+	err = p.Validate()
+	if err != nil {
+		return err
+	}
+
+	// execute the view file call for the pipeline configuration
+	//
+	// https://pkg.go.dev/github.com/go-vela/cli/action/pipeline?tab=doc#Config.View
+	return p.View(client)
+}

--- a/action/pipeline_view_test.go
+++ b/action/pipeline_view_test.go
@@ -10,10 +10,11 @@ import (
 	"testing"
 
 	"github.com/go-vela/mock/server"
+
 	"github.com/urfave/cli/v2"
 )
 
-func TestAction_PipelineValidate(t *testing.T) {
+func TestAction_PipelineView(t *testing.T) {
 	// setup test server
 	s := httptest.NewServer(server.FakeHandler())
 
@@ -29,11 +30,6 @@ func TestAction_PipelineValidate(t *testing.T) {
 	fullSet.String("repo", "octocat", "doc")
 	fullSet.String("output", "json", "doc")
 
-	// setup flags
-	localSet := flag.NewFlagSet("test", 0)
-	localSet.String("file", "generate.yml", "doc")
-	localSet.String("path", "pipeline/testdata", "doc")
-
 	// setup tests
 	tests := []struct {
 		failure bool
@@ -42,10 +38,6 @@ func TestAction_PipelineValidate(t *testing.T) {
 		{
 			failure: false,
 			set:     fullSet,
-		},
-		{
-			failure: false,
-			set:     localSet,
 		},
 		{
 			failure: true,
@@ -59,18 +51,18 @@ func TestAction_PipelineValidate(t *testing.T) {
 
 	// run tests
 	for _, test := range tests {
-		err := pipelineValidate(cli.NewContext(nil, test.set, nil))
+		err := pipelineView(cli.NewContext(nil, test.set, nil))
 
 		if test.failure {
 			if err == nil {
-				t.Errorf("pipelineValidate should have returned err")
+				t.Errorf("pipelineView should have returned err")
 			}
 
 			continue
 		}
 
 		if err != nil {
-			t.Errorf("pipelineValidate returned err: %v", err)
+			t.Errorf("pipelineView returned err: %v", err)
 		}
 	}
 }

--- a/cmd/vela-cli/compile.go
+++ b/cmd/vela-cli/compile.go
@@ -1,0 +1,26 @@
+// Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+//
+// Use of this source code is governed by the LICENSE file in this repository.
+
+package main
+
+import (
+	"github.com/go-vela/cli/action"
+
+	"github.com/urfave/cli/v2"
+)
+
+// compileCmds defines the commands for compiling resources.
+var compileCmds = &cli.Command{
+	Name:                   "compile",
+	Category:               "Resource Management",
+	Description:            "Use this command to compile a resource for Vela.",
+	Usage:                  "Compile a resource for Vela via subcommands",
+	UseShortOptionHandling: true,
+	Subcommands: []*cli.Command{
+		// add the sub command for compiling a pipeline
+		//
+		// https://pkg.go.dev/github.com/go-vela/cli/action?tab=doc#PipelineCompile
+		action.PipelineCompile,
+	},
+}

--- a/cmd/vela-cli/expand.go
+++ b/cmd/vela-cli/expand.go
@@ -1,0 +1,26 @@
+// Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+//
+// Use of this source code is governed by the LICENSE file in this repository.
+
+package main
+
+import (
+	"github.com/go-vela/cli/action"
+
+	"github.com/urfave/cli/v2"
+)
+
+// expandCmds defines the commands for expanding resources.
+var expandCmds = &cli.Command{
+	Name:                   "expand",
+	Category:               "Resource Management",
+	Description:            "Use this command to expand a resource for Vela.",
+	Usage:                  "Expand a resource for Vela via subcommands",
+	UseShortOptionHandling: true,
+	Subcommands: []*cli.Command{
+		// add the sub command for expanding a pipeline
+		//
+		// https://pkg.go.dev/github.com/go-vela/cli/action?tab=doc#PipelineExpand
+		action.PipelineExpand,
+	},
+}

--- a/cmd/vela-cli/main.go
+++ b/cmd/vela-cli/main.go
@@ -49,6 +49,8 @@ func main() {
 		action.Version,
 		addCmds,
 		chownCmds,
+		compileCmds,
+		expandCmds,
 		generateCmds,
 		getCmds,
 		removeCmds,

--- a/cmd/vela-cli/view.go
+++ b/cmd/vela-cli/view.go
@@ -44,6 +44,11 @@ var viewCmds = &cli.Command{
 		// https://pkg.go.dev/github.com/go-vela/cli/action?tab=doc#LogView
 		action.LogView,
 
+		// add the sub command for inspecting a pipeline
+		//
+		// https://pkg.go.dev/github.com/go-vela/cli/action?tab=doc#PipelineView
+		action.PipelineView,
+
 		// add the sub command for inspecting a repository
 		//
 		// https://pkg.go.dev/github.com/go-vela/cli/action?tab=doc#RepoView


### PR DESCRIPTION
Part of the [Cargill/Target Hackathon](https://gophers.slack.com/archives/CNRRKE8KY/p1602194963000100) for Vela

Related to https://github.com/go-vela/server/pull/203 and https://github.com/go-vela/cli/pull/172

Dependent on https://github.com/go-vela/sdk-go/pull/63/

Originally, I had this as one big PR:

https://github.com/go-vela/cli/pull/170 

But that is a lot of lines and files changed to review in a single PR so I've since broken it down.

This adds a collection of new `pipeline` commands:

```
$ vela compile pipeline
$ vela expand pipeline
$ vela view pipeline
```

The new commands will be added in a subsequent PR 👍 