### PR TITLE
fix(pipeline): mount local volume in read-write mode

### DIFF
--- a/action/pipeline/exec.go
+++ b/action/pipeline/exec.go
@@ -69,7 +69,7 @@ func (c *Config) Exec(client compiler.Engine) error {
 	// check if the local configuration is enabled
 	if c.Local {
 		// create current directory path for local mount
-		mount := fmt.Sprintf("%s:%s", base, constants.WorkspaceDefault)
+		mount := fmt.Sprintf("%s:%s:rw", base, constants.WorkspaceDefault)
 
 		// add the current directory path to volume mounts
 		c.Volumes = append(c.Volumes, mount)

--- a/action/pipeline_exec.go
+++ b/action/pipeline_exec.go
@@ -118,8 +118,10 @@ EXAMPLES:
     $ {{.HelpName}} --path /absolute/full/path/to/dir --file .vela.local.yml
   4. Execute a local Vela pipeline with ruleset information.
     $ {{.HelpName}} --branch master --event push
-  5. Execute a local Vela pipeline with extra local volumes.
-    $ {{.HelpName}} --volume /tmp/foo.txt:/tmp/foo.txt --volume /tmp/bar.txt:/tmp/bar.txt
+  5. Execute a local Vela pipeline with a read-only local volume.
+    $ {{.HelpName}} --volume /tmp/foo.txt:/tmp/foo.txt:ro
+  6. Execute a local Vela pipeline with a writeable local volume.
+    $ {{.HelpName}} --volume /tmp/bar.txt:/tmp/bar.txt:rw
 
 DOCUMENTATION:
 


### PR DESCRIPTION
Part of the effort for https://github.com/go-vela/community/issues/54

When running a pipeline locally, we allow you to mount in the current working directory to the build.

However, we weren't explicitly providing permissions so the code is setup to default to read-only (`ro`).

This adds `:rw` to the end of the volume mount path to ensure we mount the volume with read-write permissions.

I also updated the examples for `vela exec pipeline` to show mounting local volumes with different permissions.