### PR TITLE
fix(secrets): remove default events from update action

### DIFF
--- a/action/secret_update.go
+++ b/action/secret_update.go
@@ -84,11 +84,6 @@ var SecretUpdate = &cli.Command{
 			Name:    "event",
 			Aliases: []string{"ev"},
 			Usage:   "provide the event(s) that can access this secret",
-			Value: cli.NewStringSlice(
-				constants.EventDeploy,
-				constants.EventPush,
-				constants.EventTag,
-			),
 		},
 		&cli.StringFlag{
 			EnvVars: []string{"VELA_COMMAND", "SECRET_COMMAND"},


### PR DESCRIPTION
closes https://github.com/go-vela/community/issues/178