### PR TITLE
feat: add version information to executor

### DIFF
--- a/action/pipeline/exec.go
+++ b/action/pipeline/exec.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/go-vela/cli/version"
 	"github.com/go-vela/compiler/compiler"
 	"github.com/go-vela/pkg-executor/executor"
 	"github.com/go-vela/pkg-runtime/runtime"
@@ -99,6 +100,7 @@ func (c *Config) Exec(client compiler.Engine) error {
 		Pipeline: _pipeline.Sanitize(constants.DriverDocker),
 		Build:    b,
 		Repo:     r,
+		Version:  version.New().Semantic(),
 	})
 	if err != nil {
 		return err

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/dustin/go-humanize v1.0.0
 	github.com/go-vela/compiler v0.7.0-rc2
 	github.com/go-vela/mock v0.7.0-rc2
-	github.com/go-vela/pkg-executor v0.7.0-rc2
+	github.com/go-vela/pkg-executor v0.7.0-rc2.0.20210125155500-a6fec1db703f
 	github.com/go-vela/pkg-runtime v0.7.0-rc2
 	github.com/go-vela/sdk-go v0.7.0-rc2
 	github.com/go-vela/types v0.7.0-rc2

--- a/go.sum
+++ b/go.sum
@@ -144,8 +144,8 @@ github.com/go-vela/compiler v0.7.0-rc2 h1:oqEzF1rbQYTDepgWX5YWVmoPMHwYCPZFByb4WE
 github.com/go-vela/compiler v0.7.0-rc2/go.mod h1:yDLkztd1U/29EPleiBbkNzPWnxxUwvKNGYMTX3pYPQ8=
 github.com/go-vela/mock v0.7.0-rc2 h1:n+ugukio7vQrmOZ5D2td+BuGufqrT2HT3gZHO1UPeRc=
 github.com/go-vela/mock v0.7.0-rc2/go.mod h1:PzRHohJqr9xLxpe8482/kwL9bHy2YuKtOhzMohxYaYk=
-github.com/go-vela/pkg-executor v0.7.0-rc2 h1:Tlv6oMZDKU0CkT1GP3KsI6xmYEGvRGblD9Tz3Y/wdI4=
-github.com/go-vela/pkg-executor v0.7.0-rc2/go.mod h1:fZSgpMre5zppQayDBXvHk+OhTc69IVzxEl0PnniVxPk=
+github.com/go-vela/pkg-executor v0.7.0-rc2.0.20210125155500-a6fec1db703f h1:ONz4EBCrIXhQVsxnPL7g0xZEmdtIf82AhQUh5rpKslw=
+github.com/go-vela/pkg-executor v0.7.0-rc2.0.20210125155500-a6fec1db703f/go.mod h1:fZSgpMre5zppQayDBXvHk+OhTc69IVzxEl0PnniVxPk=
 github.com/go-vela/pkg-runtime v0.7.0-rc2 h1:/t1F4wXsGsk1vEdKH6asadD3IeK6ocjmaytlp1AwGXM=
 github.com/go-vela/pkg-runtime v0.7.0-rc2/go.mod h1:gzlGU38GT9SE20p5YpoPl0S1iVmCr6xaIB+kAtUFzo0=
 github.com/go-vela/sdk-go v0.7.0-rc2 h1:i6CWvEFWyJqMDAQhqYy2+cRnZS1ENs2Ex3CLOExPhjI=


### PR DESCRIPTION
Part of the effort for https://github.com/go-vela/community/issues/54

Based off of https://github.com/go-vela/pkg-executor/pull/110

This will set the version information for the executor which is used in environment variables.