### PR TITLE
fix(links): update doc link references

### DIFF
--- a/action/build_cancel.go
+++ b/action/build_cancel.go
@@ -66,7 +66,7 @@ EXAMPLES:
 
 DOCUMENTATION:
 
-  https://go-vela.github.io/docs/cli/build/cancel/
+  https://go-vela.github.io/docs/reference/cli/build/cancel/
 `, cli.CommandHelpTemplate),
 }
 

--- a/action/build_get.go
+++ b/action/build_get.go
@@ -79,7 +79,7 @@ EXAMPLES:
 
 DOCUMENTATION:
 
-  https://go-vela.github.io/docs/cli/build/get/
+  https://go-vela.github.io/docs/reference/cli/build/get/
 `, cli.CommandHelpTemplate),
 }
 

--- a/action/build_restart.go
+++ b/action/build_restart.go
@@ -64,7 +64,7 @@ EXAMPLES:
 
 DOCUMENTATION:
 
-  https://go-vela.github.io/docs/cli/build/restart/
+  https://go-vela.github.io/docs/reference/cli/build/restart/
 `, cli.CommandHelpTemplate),
 }
 

--- a/action/build_view.go
+++ b/action/build_view.go
@@ -67,7 +67,7 @@ EXAMPLES:
 
 DOCUMENTATION:
 
-  https://go-vela.github.io/docs/cli/build/view/
+  https://go-vela.github.io/docs/reference/cli/build/view/
 `, cli.CommandHelpTemplate),
 }
 

--- a/action/completion_generate.go
+++ b/action/completion_generate.go
@@ -44,13 +44,13 @@ EXAMPLES:
   2. Enable auto completion for the current zsh session.
     $ source <({{.HelpName}} --zsh true)
   3. Enable auto completion for bash permanently.
-    visit https://go-vela.github.io/docs/cli/completion/generate/#bash
+    visit https://go-vela.github.io/docs/reference/cli/completion/generate/#bash
   4. Enable auto completion for zsh permanently.
-    visit https://go-vela.github.io/docs/cli/completion/generate/#zsh
+    visit https://go-vela.github.io/docs/reference/cli/completion/generate/#zsh
 
 DOCUMENTATION:
 
-  https://go-vela.github.io/docs/cli/completion/generate/
+  https://go-vela.github.io/docs/reference/cli/completion/generate/
 `, cli.CommandHelpTemplate),
 }
 

--- a/action/config_generate.go
+++ b/action/config_generate.go
@@ -117,7 +117,7 @@ EXAMPLES:
 
 DOCUMENTATION:
 
-  https://go-vela.github.io/docs/cli/config/generate/
+  https://go-vela.github.io/docs/reference/cli/config/generate/
 `, cli.CommandHelpTemplate),
 }
 

--- a/action/config_remove.go
+++ b/action/config_remove.go
@@ -126,7 +126,7 @@ EXAMPLES:
 
 DOCUMENTATION:
 
-  https://go-vela.github.io/docs/cli/config/remove/
+  https://go-vela.github.io/docs/reference/cli/config/remove/
 `, cli.CommandHelpTemplate),
 }
 

--- a/action/config_update.go
+++ b/action/config_update.go
@@ -117,7 +117,7 @@ EXAMPLES:
 
 DOCUMENTATION:
 
-  https://go-vela.github.io/docs/cli/config/update/
+  https://go-vela.github.io/docs/reference/cli/config/update/
 `, cli.CommandHelpTemplate),
 }
 

--- a/action/config_view.go
+++ b/action/config_view.go
@@ -26,7 +26,7 @@ EXAMPLES:
 
 DOCUMENTATION:
 
-  https://go-vela.github.io/docs/cli/config/view/
+  https://go-vela.github.io/docs/reference/cli/config/view/
 `, cli.CommandHelpTemplate),
 }
 

--- a/action/deployment_add.go
+++ b/action/deployment_add.go
@@ -101,7 +101,7 @@ EXAMPLES:
 
 DOCUMENTATION:
 
-  https://go-vela.github.io/docs/cli/deployment/add/
+  https://go-vela.github.io/docs/reference/cli/deployment/add/
 `, cli.CommandHelpTemplate),
 }
 

--- a/action/deployment_get.go
+++ b/action/deployment_get.go
@@ -79,7 +79,7 @@ EXAMPLES:
 
 DOCUMENTATION:
 
-  https://go-vela.github.io/docs/cli/deployment/get/
+  https://go-vela.github.io/docs/reference/cli/deployment/get/
 `, cli.CommandHelpTemplate),
 }
 

--- a/action/deployment_view.go
+++ b/action/deployment_view.go
@@ -67,7 +67,7 @@ EXAMPLES:
 
 DOCUMENTATION:
 
-  https://go-vela.github.io/docs/cli/deployment/view/
+  https://go-vela.github.io/docs/reference/cli/deployment/view/
 `, cli.CommandHelpTemplate),
 }
 

--- a/action/docs_generate.go
+++ b/action/docs_generate.go
@@ -47,7 +47,7 @@ EXAMPLES:
 
 DOCUMENTATION:
 
-  https://go-vela.github.io/docs/cli/docs/generate/
+  https://go-vela.github.io/docs/reference/cli/docs/generate/
 `, cli.CommandHelpTemplate),
 }
 

--- a/action/hook_get.go
+++ b/action/hook_get.go
@@ -79,7 +79,7 @@ EXAMPLES:
 
 DOCUMENTATION:
 
-  https://go-vela.github.io/docs/cli/hook/get/
+  https://go-vela.github.io/docs/reference/cli/hook/get/
 `, cli.CommandHelpTemplate),
 }
 

--- a/action/hook_view.go
+++ b/action/hook_view.go
@@ -66,7 +66,7 @@ EXAMPLES:
 
 DOCUMENTATION:
 
-  https://go-vela.github.io/docs/cli/hook/view/
+  https://go-vela.github.io/docs/reference/cli/hook/view/
 `, cli.CommandHelpTemplate),
 }
 

--- a/action/log_get.go
+++ b/action/log_get.go
@@ -69,7 +69,7 @@ EXAMPLES:
 
 DOCUMENTATION:
 
-  https://go-vela.github.io/docs/cli/log/get/
+  https://go-vela.github.io/docs/reference/cli/log/get/
 `, cli.CommandHelpTemplate),
 }
 

--- a/action/log_view.go
+++ b/action/log_view.go
@@ -88,7 +88,7 @@ EXAMPLES:
 
 DOCUMENTATION:
 
-  https://go-vela.github.io/docs/cli/log/view/
+  https://go-vela.github.io/docs/reference/cli/log/view/
 `, cli.CommandHelpTemplate),
 }
 

--- a/action/login.go
+++ b/action/login.go
@@ -62,7 +62,7 @@ EXAMPLES:
 
 DOCUMENTATION:
 
-  https://go-vela.github.io/docs/cli/login/
+  https://go-vela.github.io/docs/reference/cli/login/
 `, cli.CommandHelpTemplate),
 }
 

--- a/action/pipeline_compile.go
+++ b/action/pipeline_compile.go
@@ -67,7 +67,7 @@ EXAMPLES:
 
 DOCUMENTATION:
 
-  https://go-vela.github.io/docs/cli/pipeline/compile/
+  https://go-vela.github.io/docs/reference/cli/pipeline/compile/
 `, cli.CommandHelpTemplate),
 }
 

--- a/action/pipeline_exec.go
+++ b/action/pipeline_exec.go
@@ -125,7 +125,7 @@ EXAMPLES:
 
 DOCUMENTATION:
 
-  https://go-vela.github.io/docs/cli/pipeline/exec/
+  https://go-vela.github.io/docs/reference/cli/pipeline/exec/
 `, cli.CommandHelpTemplate),
 }
 

--- a/action/pipeline_expand.go
+++ b/action/pipeline_expand.go
@@ -67,7 +67,7 @@ EXAMPLES:
 
 DOCUMENTATION:
 
-  https://go-vela.github.io/docs/cli/pipeline/expand/
+  https://go-vela.github.io/docs/reference/cli/pipeline/expand/
 `, cli.CommandHelpTemplate),
 }
 

--- a/action/pipeline_generate.go
+++ b/action/pipeline_generate.go
@@ -68,7 +68,7 @@ EXAMPLES:
 
 DOCUMENTATION:
 
-  https://go-vela.github.io/docs/cli/pipeline/generate/
+  https://go-vela.github.io/docs/reference/cli/pipeline/generate/
 `, cli.CommandHelpTemplate),
 }
 

--- a/action/pipeline_validate.go
+++ b/action/pipeline_validate.go
@@ -81,7 +81,7 @@ EXAMPLES:
     $ {{.HelpName}} --org MyOrg --repo MyRepo --output json
 DOCUMENTATION:
 
-  https://go-vela.github.io/docs/cli/pipeline/validate/
+  https://go-vela.github.io/docs/reference/cli/pipeline/validate/
 `, cli.CommandHelpTemplate),
 }
 

--- a/action/pipeline_view.go
+++ b/action/pipeline_view.go
@@ -67,7 +67,7 @@ EXAMPLES:
 
 DOCUMENTATION:
 
-  https://go-vela.github.io/docs/cli/pipeline/view/
+  https://go-vela.github.io/docs/reference/cli/pipeline/view/
 `, cli.CommandHelpTemplate),
 }
 

--- a/action/repo_add.go
+++ b/action/repo_add.go
@@ -125,7 +125,7 @@ EXAMPLES:
 
 DOCUMENTATION:
 
-  https://go-vela.github.io/docs/cli/repo/add/
+  https://go-vela.github.io/docs/reference/cli/repo/add/
 `, cli.CommandHelpTemplate),
 }
 

--- a/action/repo_chown.go
+++ b/action/repo_chown.go
@@ -57,7 +57,7 @@ EXAMPLES:
 
 DOCUMENTATION:
 
-  https://go-vela.github.io/docs/cli/repo/chown/
+  https://go-vela.github.io/docs/reference/cli/repo/chown/
 `, cli.CommandHelpTemplate),
 }
 

--- a/action/repo_get.go
+++ b/action/repo_get.go
@@ -64,7 +64,7 @@ EXAMPLES:
 
 DOCUMENTATION:
 
-  https://go-vela.github.io/docs/cli/repo/get/
+  https://go-vela.github.io/docs/reference/cli/repo/get/
 `, cli.CommandHelpTemplate),
 }
 

--- a/action/repo_remove.go
+++ b/action/repo_remove.go
@@ -57,7 +57,7 @@ EXAMPLES:
 
 DOCUMENTATION:
 
-  https://go-vela.github.io/docs/cli/repo/remove/
+  https://go-vela.github.io/docs/reference/cli/repo/remove/
 `, cli.CommandHelpTemplate),
 }
 

--- a/action/repo_repair.go
+++ b/action/repo_repair.go
@@ -57,7 +57,7 @@ EXAMPLES:
 
 DOCUMENTATION:
 
-  https://go-vela.github.io/docs/cli/repo/repair/
+  https://go-vela.github.io/docs/reference/cli/repo/repair/
 `, cli.CommandHelpTemplate),
 }
 

--- a/action/repo_update.go
+++ b/action/repo_update.go
@@ -125,7 +125,7 @@ EXAMPLES:
 
 DOCUMENTATION:
 
-  https://go-vela.github.io/docs/cli/repo/update/
+  https://go-vela.github.io/docs/reference/cli/repo/update/
 `, cli.CommandHelpTemplate),
 }
 

--- a/action/repo_view.go
+++ b/action/repo_view.go
@@ -58,7 +58,7 @@ EXAMPLES:
 
 DOCUMENTATION:
 
-  https://go-vela.github.io/docs/cli/repo/view/
+  https://go-vela.github.io/docs/reference/cli/repo/view/
 `, cli.CommandHelpTemplate),
 }
 

--- a/action/secret_add.go
+++ b/action/secret_add.go
@@ -136,7 +136,7 @@ EXAMPLES:
 
 DOCUMENTATION:
 
-  https://go-vela.github.io/docs/cli/secret/add/
+  https://go-vela.github.io/docs/reference/cli/secret/add/
 `, cli.CommandHelpTemplate),
 }
 

--- a/action/secret_get.go
+++ b/action/secret_get.go
@@ -104,7 +104,7 @@ EXAMPLES:
 
 DOCUMENTATION:
 
-  https://go-vela.github.io/docs/cli/secret/get/
+  https://go-vela.github.io/docs/reference/cli/secret/get/
 `, cli.CommandHelpTemplate),
 }
 

--- a/action/secret_remove.go
+++ b/action/secret_remove.go
@@ -92,7 +92,7 @@ EXAMPLES:
 
 DOCUMENTATION:
 
-  https://go-vela.github.io/docs/cli/secret/remove/
+  https://go-vela.github.io/docs/reference/cli/secret/remove/
 `, cli.CommandHelpTemplate),
 }
 

--- a/action/secret_update.go
+++ b/action/secret_update.go
@@ -131,7 +131,7 @@ EXAMPLES:
 
 DOCUMENTATION:
 
-  https://go-vela.github.io/docs/cli/secret/update/
+  https://go-vela.github.io/docs/reference/cli/secret/update/
 `, cli.CommandHelpTemplate),
 }
 

--- a/action/secret_view.go
+++ b/action/secret_view.go
@@ -92,7 +92,7 @@ EXAMPLES:
 
 DOCUMENTATION:
 
-  https://go-vela.github.io/docs/cli/secret/view/
+  https://go-vela.github.io/docs/reference/cli/secret/view/
 `, cli.CommandHelpTemplate),
 }
 

--- a/action/service_get.go
+++ b/action/service_get.go
@@ -88,7 +88,7 @@ EXAMPLES:
 
 DOCUMENTATION:
 
-  https://go-vela.github.io/docs/cli/service/get/
+  https://go-vela.github.io/docs/reference/cli/service/get/
 `, cli.CommandHelpTemplate),
 }
 

--- a/action/service_view.go
+++ b/action/service_view.go
@@ -76,7 +76,7 @@ EXAMPLES:
 
 DOCUMENTATION:
 
-  https://go-vela.github.io/docs/cli/service/view/
+  https://go-vela.github.io/docs/reference/cli/service/view/
 `, cli.CommandHelpTemplate),
 }
 

--- a/action/step_get.go
+++ b/action/step_get.go
@@ -88,7 +88,7 @@ EXAMPLES:
 
 DOCUMENTATION:
 
-  https://go-vela.github.io/docs/cli/step/get/
+  https://go-vela.github.io/docs/reference/cli/step/get/
 `, cli.CommandHelpTemplate),
 }
 

--- a/action/step_view.go
+++ b/action/step_view.go
@@ -76,7 +76,7 @@ EXAMPLES:
 
 DOCUMENTATION:
 
-  https://go-vela.github.io/docs/cli/step/view/
+  https://go-vela.github.io/docs/reference/cli/step/view/
 `, cli.CommandHelpTemplate),
 }
 

--- a/action/version.go
+++ b/action/version.go
@@ -40,7 +40,7 @@ EXAMPLES:
 
 DOCUMENTATION:
 
-  https://go-vela.github.io/docs/cli/version/
+  https://go-vela.github.io/docs/reference/cli/version/
 `, cli.CommandHelpTemplate),
 }
 


### PR DESCRIPTION
to note - these currently referenced pages do not exist at the time this PR was opened.

https://go-vela.github.io/docs/reference/cli/docs/generate/
https://go-vela.github.io/docs/reference/cli/version/
https://go-vela.github.io/docs/reference/cli/build/cancel/