### PR TITLE
chore: linter setup and fixes, doc changes

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -22,6 +22,7 @@ We are always open to new PRs! You can follow the below guide for learning how y
 
 * [Review the commit guide we follow](https://chris.beams.io/posts/git-commit/#seven-rules) - ensure your commits follow our standards
 * [Golang](https://golang.org/dl/) - for source code and [dependency management](https://github.com/golang/go/wiki/Modules)
+* [Make](https://www.gnu.org/software/make/) - start up local development
 
 ### Setup
 
@@ -60,15 +61,23 @@ cd $HOME/go-vela/cli
 * Build the repository code:
 
 ```bash
-# Build the code with `go`
-CGO_ENABLED=0 go build -o ./vela-cli github.com/go-vela/cli
+# execute the `build` target with `make`
+make build
+
+# This command will output binaries to the following locations:
+#
+# * $HOME/go-vela/cli/release/darwin/amd64/vela
+# * $HOME/go-vela/cli/release/linux/amd64/vela
+# * $HOME/go-vela/cli/release/linux/arm64/vela
+# * $HOME/go-vela/cli/release/linux/arm/vela
+# * $HOME/go-vela/cli/release/windows/amd64/vela
 ```
 
 * Run the repository code:
 
 ```bash
-# Run the code
-./vela-cli
+# run the Go binary for your specific operating system and architecture
+release/darwin/amd64/vela
 ```
 
 ### Development
@@ -80,23 +89,37 @@ CGO_ENABLED=0 go build -o ./vela-cli github.com/go-vela/cli
 cd $HOME/go-vela/cli
 ```
 
-* Write your code and [test locally](#running-locally)
-  - Please be sure to [follow our commit rules](https://chris.beams.io/posts/git-commit/#seven-rules)
+* Write your code and tests to implement the changes you desire.
+  * Please be sure to [follow our commit rules](https://chris.beams.io/posts/git-commit/#seven-rules)
+  * Please address linter warnings appropriately. If you are intentionally violating a rule that triggers a linter, please annotate the respective code with `nolint` declarations [[docs](https://golangci-lint.run/usage/false-positives/)]. we are using the following format for `nolint` declarations:
 
-* Write tests for your changes and ensure they pass:
+    ```go
+    // nolint:<linter(s)> // <short reason>
+    ```
+  
+    Example:
+
+    ```go
+    // nolint:gocyclo // legacy function is complex, needs simplification
+    func superComplexFunction() error {
+      // ..
+    }
+    ```
+
+    Check the [documentation for more examples](https://golangci-lint.run/usage/false-positives/).
+
+* Test the repository code (ensures your changes don't break existing functionality):
 
 ```bash
-# Test the code with `go`
-go test ./...
+# execute the `test` target with `make`
+make test
 ```
 
-* Ensure your code meets the project standards:
+* Clean the repository code (ensures your code meets the project standards):
 
 ```bash
-# Clean the code with `go`
-go mod tidy
-go fmt ./...
-go vet ./...
+# execute the `test` target with `make`
+make clean
 ```
 
 * Push to your fork:
@@ -106,4 +129,25 @@ go vet ./...
 git push fork master
 ```
 
-* Open a pull request. Thank you for your contribution!
+* Open a pull request!
+  * For the title of the pull request, please use the following format for the title:
+
+    ```text
+    feat(wobble): add hat wobble
+    ^--^^------^  ^------------^
+    |   |         |
+    |   |         +---> Summary in present tense.
+    |   +---> Scope: a noun describing a section of the codebase (optional)
+    +---> Type: chore, docs, feat, fix, refactor, or test.
+    ```
+
+    * feat: adds a new feature (equivalent to a MINOR in Semantic Versioning)
+    * fix: fixes a bug (equivalent to a PATCH in Semantic Versioning)
+    * docs: changes to the documentation
+    * refactor: refactors production code, eg. renaming a variable; doesn't change public API
+    * test: adds missing tests, refactors tests; no production code change
+    * chore: updates something without impacting the user (ex: bump a dependency in package.json or go.mod); no production code change
+
+    If a code change introduces a breaking change, place ! suffix after type, ie. feat(change)!: adds breaking change. correlates with MAJOR in semantic versioning.
+
+Thank you for your contribution!

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -56,10 +56,10 @@ linters-settings:
 
   # https://github.com/golangci/golangci-lint/blob/master/pkg/golinters/nolintlint
   nolintlint:
-    allow-leading-space: true # don't require machine-readable nolint directives (i.e. with no leading space)
-    allow-unused: false # report any unused nolint directives
-    require-explanation: false # don't require an explanation for nolint directives
-    require-specific: false # don't require nolint directives to be specific about which linter is being skipped
+    allow-leading-space: true # allow non-"machine-readable" format (ie. with leading space) 
+    allow-unused: false # allow nolint directives that don't address a linting issue
+    require-explanation: true # require an explanation for nolint directives
+    require-specific: true # require nolint directives to be specific about which linter is being skipped
 
 # This section provides the configuration for which linters
 # golangci will execute. Several of them were disabled by
@@ -131,7 +131,9 @@ issues:
     # prevent linters from running on *_test.go files
     - path: _test\.go
       linters:
+        - dupl
         - funlen
         - goconst
         - gocyclo
         - gomnd
+        - lll

--- a/action/action.go
+++ b/action/action.go
@@ -4,7 +4,7 @@
 
 package action
 
-// list of defined actions
+// list of defined actions.
 const (
 	// addAction defines the action for creating a resource.
 	addAction = "add"
@@ -32,9 +32,6 @@ const (
 
 	// loadAction defines the action for loading a resource.
 	loadAction = "load"
-
-	// loginAction defines the action for logging in to Vela.
-	loginAction = "login"
 
 	// removeAction defines the action for deleting a resource.
 	removeAction = "remove"

--- a/action/build/cancel_test.go
+++ b/action/build/cancel_test.go
@@ -2,8 +2,6 @@
 //
 // Use of this source code is governed by the LICENSE file in this repository.
 
-// Package build contains resources for managing builds
-// nolint:dupl // code is similar to action/build_restart.go, but is not duplicative
 package build
 
 import (

--- a/action/build/restart.go
+++ b/action/build/restart.go
@@ -2,6 +2,7 @@
 //
 // Use of this source code is governed by the LICENSE file in this repository.
 
+// nolint: dupl // ignore similar code among actions
 package build
 
 import (

--- a/action/build/table.go
+++ b/action/build/table.go
@@ -53,6 +53,8 @@ func table(builds *[]library.Build) error {
 		logrus.Tracef("adding build %d to build table", b.GetNumber())
 
 		// calculate duration based off the build timestamps
+		//
+		// nolint: gosec // ignore memory aliasing
 		d := duration(&b)
 
 		// add a row to the table with the specified values
@@ -93,6 +95,8 @@ func wideTable(builds *[]library.Build) error {
 	// set of build fields we display in a wide table
 	//
 	// https://pkg.go.dev/github.com/gosuri/uitable?tab=doc#Table.AddRow
+	//
+	// nolint: lll // ignore long line length due to number of columns
 	table.AddRow("NUMBER", "STATUS", "EVENT", "BRANCH", "COMMIT", "DURATION", "CREATED", "FINISHED", "AUTHOR")
 
 	// iterate through all builds in the list
@@ -100,6 +104,8 @@ func wideTable(builds *[]library.Build) error {
 		logrus.Tracef("adding build %d to wide build table", b.GetNumber())
 
 		// calculate duration based off the build timestamps
+		//
+		// nolint: gosec // ignore memory aliasing
 		d := duration(&b)
 
 		// calculate created timestamp in human readable form
@@ -115,6 +121,8 @@ func wideTable(builds *[]library.Build) error {
 		// add a row to the table with the specified values
 		//
 		// https://pkg.go.dev/github.com/gosuri/uitable?tab=doc#Table.AddRow
+		//
+		// nolint: lll // ignore long line length due to number of columns
 		table.AddRow(b.GetNumber(), b.GetStatus(), b.GetEvent(), b.GetBranch(), b.GetCommit(), d, c, f, b.GetAuthor())
 	}
 

--- a/action/build/view.go
+++ b/action/build/view.go
@@ -2,6 +2,7 @@
 //
 // Use of this source code is governed by the LICENSE file in this repository.
 
+// nolint: dupl // ignore similar code among actions
 package build
 
 import (

--- a/action/build_cancel.go
+++ b/action/build_cancel.go
@@ -2,8 +2,7 @@
 //
 // Use of this source code is governed by the LICENSE file in this repository.
 
-// Package action contains all cli actions
-// nolint:dupl // code is similar to action/build_restart.go, but is not duplicative
+// nolint: dupl // ignore similar code among actions
 package action
 
 import (

--- a/action/build_cancel_test.go
+++ b/action/build_cancel_test.go
@@ -3,7 +3,6 @@
 // Use of this source code is governed by the LICENSE file in this repository.
 
 // Package action contains all cli actions
-// nolint:dupl // code is similar to action/build_restart.go, but is not duplicative
 package action
 
 import (

--- a/action/build_get.go
+++ b/action/build_get.go
@@ -86,6 +86,8 @@ DOCUMENTATION:
 // helper function to capture the provided
 // input and create the object used to
 // capture a list of builds.
+//
+// nolint: dupl // ignore similar code among actions
 func buildGet(c *cli.Context) error {
 	// load variables from the config file
 	err := load(c)

--- a/action/build_restart.go
+++ b/action/build_restart.go
@@ -2,6 +2,7 @@
 //
 // Use of this source code is governed by the LICENSE file in this repository.
 
+// nolint: dupl // ignore similar code among actions
 package action
 
 import (

--- a/action/build_view.go
+++ b/action/build_view.go
@@ -74,6 +74,8 @@ DOCUMENTATION:
 // helper function to capture the provided
 // input and create the object used to
 // inspect a build.
+//
+// nolint: dupl // ignore similar code among actions
 func buildView(c *cli.Context) error {
 	// load variables from the config file
 	err := load(c)

--- a/action/completion/zsh.go
+++ b/action/completion/zsh.go
@@ -7,6 +7,8 @@ package completion
 // ZshAutoComplete represents the script used
 // to enable automatic completion for the
 // Zsh (https://ohmyz.sh/) Unix shell.
+//
+// nolint: lll // ignore long line length
 const ZshAutoComplete = `#comdef vela
   _cli_zsh_autocomplete() {
     local -a opts

--- a/action/config/file.go
+++ b/action/config/file.go
@@ -6,6 +6,8 @@ package config
 
 // ConfigFile represents the configuration file
 // to perform config related requests with Vela.
+//
+// nolint: golint // ignore studder for package and struct name
 type ConfigFile struct {
 	API    *API    `yaml:"api,omitempty"`
 	Log    *Log    `yaml:"log,omitempty"`

--- a/action/config/generate.go
+++ b/action/config/generate.go
@@ -78,5 +78,5 @@ func (c *Config) Generate() error {
 	// send Filesystem call to create config file
 	//
 	// https://pkg.go.dev/github.com/spf13/afero?tab=doc#Afero.WriteFile
-	return a.WriteFile(c.File, []byte(out), 0600)
+	return a.WriteFile(c.File, out, 0600)
 }

--- a/action/config/load.go
+++ b/action/config/load.go
@@ -19,6 +19,8 @@ import (
 )
 
 // Load reads the config file and sets the values based off the provided configuration.
+//
+// nolint: funlen,gocyclo // ignore cyclomatic complexity and function length
 func (c *Config) Load(ctx *cli.Context) error {
 	logrus.Debug("executing load for config file configuration")
 

--- a/action/config/load_test.go
+++ b/action/config/load_test.go
@@ -34,7 +34,10 @@ func TestConfig_Config_Load(t *testing.T) {
 
 	// setup flags
 	configSet := flag.NewFlagSet("test", 0)
-	configSet.Parse([]string{"view", "config"})
+	err := configSet.Parse([]string{"view", "config"})
+	if err != nil {
+		t.Errorf("unable to parse configset: %v", err)
+	}
 
 	fullSet := flag.NewFlagSet("test", 0)
 	fullSet.String("api.addr", "https://vela-server.localhost", "doc")

--- a/action/config/remove.go
+++ b/action/config/remove.go
@@ -17,6 +17,8 @@ import (
 )
 
 // Remove deletes one or more fields from the config file based off the provided configuration.
+//
+// nolint: funlen // ignore function length due to comments and conditionals
 func (c *Config) Remove() error {
 	logrus.Debug("executing remove for config file configuration")
 
@@ -146,5 +148,5 @@ func (c *Config) Remove() error {
 	// send Filesystem call to create config file
 	//
 	// https://pkg.go.dev/github.com/spf13/afero?tab=doc#Afero.WriteFile
-	return a.WriteFile(c.File, []byte(out), 0600)
+	return a.WriteFile(c.File, out, 0600)
 }

--- a/action/config/update.go
+++ b/action/config/update.go
@@ -17,6 +17,8 @@ import (
 )
 
 // Update modifies one or more fields from the config file based off the provided configuration.
+//
+// nolint: funlen // ignore function length due to comments and conditionals
 func (c *Config) Update() error {
 	logrus.Debug("executing update for config file configuration")
 
@@ -136,5 +138,5 @@ func (c *Config) Update() error {
 	// send Filesystem call to create config file
 	//
 	// https://pkg.go.dev/github.com/spf13/afero?tab=doc#Afero.WriteFile
-	return a.WriteFile(c.File, []byte(out), 0600)
+	return a.WriteFile(c.File, out, 0600)
 }

--- a/action/config_generate.go
+++ b/action/config_generate.go
@@ -14,6 +14,8 @@ import (
 )
 
 // ConfigGenerate defines the command for producing the config file.
+//
+// nolint: dupl // ignore similar code among actions
 var ConfigGenerate = &cli.Command{
 	Name:        "config",
 	Description: "Use this command to generate the config file.",

--- a/action/config_update.go
+++ b/action/config_update.go
@@ -14,6 +14,8 @@ import (
 )
 
 // ConfigUpdate defines the command for modifying one or more fields from the config file.
+//
+// nolint: dupl // ignore similar code among actions
 var ConfigUpdate = &cli.Command{
 	Name:        "config",
 	Description: "Use this command to update one or more fields from the config file.",

--- a/action/deployment/add.go
+++ b/action/deployment/add.go
@@ -18,12 +18,13 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-// parseKeyValue converts the slice of key=value into a map
+// parseKeyValue converts the slice of key=value into a map.
 func parseKeyValue(input []string) (raw.StringSliceMap, error) {
 	payload := raw.StringSliceMap{}
 	for _, i := range input {
 		parts := strings.SplitN(i, "=", 2)
-		if len(parts) != 2 { //nolint
+		// nolint: gomnd // ignore magic number
+		if len(parts) != 2 {
 			return nil, fmt.Errorf("%s is not in key=value format", i)
 		}
 		payload[parts[0]] = parts[1]

--- a/action/deployment/table.go
+++ b/action/deployment/table.go
@@ -95,6 +95,8 @@ func wideTable(deployments *[]library.Deployment) error {
 		// add a row to the table with the specified values
 		//
 		// https://pkg.go.dev/github.com/gosuri/uitable?tab=doc#Table.AddRow
+		//
+		// nolint: lll // ignore long line length due to number of columns
 		table.AddRow(d.GetID(), d.GetTask(), d.GetUser(), d.GetRef(), d.GetTarget(), d.GetCommit(), d.GetDescription())
 	}
 

--- a/action/deployment_get.go
+++ b/action/deployment_get.go
@@ -2,6 +2,7 @@
 //
 // Use of this source code is governed by the LICENSE file in this repository.
 
+// nolint: dupl // ignore similar code among actions
 package action
 
 import (
@@ -86,6 +87,8 @@ DOCUMENTATION:
 // helper function to capture the provided
 // input and create the object used to
 // capture a list of deployments.
+//
+// nolint: dupl // ignore similar code among actions
 func deploymentGet(c *cli.Context) error {
 	// load variables from the config file
 	err := load(c)

--- a/action/deployment_view.go
+++ b/action/deployment_view.go
@@ -74,6 +74,8 @@ DOCUMENTATION:
 // helper function to capture the provided
 // input and create the object used to
 // inspect a deployment.
+//
+// nolint: dupl // ignore similar code among actions
 func deploymentView(c *cli.Context) error {
 	// load variables from the config file
 	err := load(c)

--- a/action/hook/table.go
+++ b/action/hook/table.go
@@ -107,6 +107,8 @@ func wideTable(hooks *[]library.Hook) error {
 		// add a row to the table with the specified values
 		//
 		// https://pkg.go.dev/github.com/gosuri/uitable?tab=doc#Table.AddRow
+		//
+		// nolint: lll // ignore long line length due to number of columns
 		table.AddRow(h.GetNumber(), h.GetSourceID(), h.GetStatus(), h.GetHost(), h.GetEvent(), h.GetBranch(), c)
 	}
 

--- a/action/hook_get.go
+++ b/action/hook_get.go
@@ -2,6 +2,7 @@
 //
 // Use of this source code is governed by the LICENSE file in this repository.
 
+// nolint: dupl // ignore similar code among actions
 package action
 
 import (
@@ -86,6 +87,8 @@ DOCUMENTATION:
 // helper function to capture the provided
 // input and create the object used to
 // capture a list of hooks.
+//
+// nolint: dupl // ignore similar code among actions
 func hookGet(c *cli.Context) error {
 	// load variables from the config file
 	err := load(c)

--- a/action/hook_view.go
+++ b/action/hook_view.go
@@ -73,6 +73,8 @@ DOCUMENTATION:
 // helper function to capture the provided
 // input and create the object used to
 // inspect a hook.
+//
+// nolint: dupl // ignore similar code among actions
 func hookView(c *cli.Context) error {
 	// load variables from the config file
 	err := load(c)

--- a/action/log/view.go
+++ b/action/log/view.go
@@ -13,6 +13,8 @@ import (
 )
 
 // ViewService inspects a service log based on the provided configuration.
+//
+// nolint: dupl // ignore similar code among actions
 func (c *Config) ViewService(client *vela.Client) error {
 	logrus.Debug("executing view service for log configuration")
 
@@ -57,6 +59,8 @@ func (c *Config) ViewService(client *vela.Client) error {
 }
 
 // ViewStep inspects a service log based on the provided configuration.
+//
+// nolint: dupl // ignore similar code among actions
 func (c *Config) ViewStep(client *vela.Client) error {
 	logrus.Debug("executing view step for log configuration")
 

--- a/action/log_get.go
+++ b/action/log_get.go
@@ -76,6 +76,8 @@ DOCUMENTATION:
 // helper function to capture the provided
 // input and create the object used to
 // capture a list of build logs.
+//
+// nolint: dupl // ignore similar code among actions
 func logGet(c *cli.Context) error {
 	// load variables from the config file
 	err := load(c)

--- a/action/pipeline/compile.go
+++ b/action/pipeline/compile.go
@@ -2,6 +2,7 @@
 //
 // Use of this source code is governed by the LICENSE file in this repository.
 
+// nolint: dupl // ignore similar code among actions
 package pipeline
 
 import (

--- a/action/pipeline/expand.go
+++ b/action/pipeline/expand.go
@@ -2,6 +2,7 @@
 //
 // Use of this source code is governed by the LICENSE file in this repository.
 
+// nolint: dupl // ignore similar code among actions
 package pipeline
 
 import (

--- a/action/pipeline/generate.go
+++ b/action/pipeline/generate.go
@@ -79,5 +79,5 @@ func (c *Config) Generate() error {
 	// send Filesystem call to create pipeline file
 	//
 	// https://pkg.go.dev/github.com/spf13/afero?tab=doc#Afero.WriteFile
-	return a.WriteFile(path, []byte(out), 0644)
+	return a.WriteFile(path, out, 0644)
 }

--- a/action/pipeline/view.go
+++ b/action/pipeline/view.go
@@ -2,6 +2,7 @@
 //
 // Use of this source code is governed by the LICENSE file in this repository.
 
+// nolint: dupl // ignore similar code among actions
 package pipeline
 
 import (

--- a/action/pipeline_compile.go
+++ b/action/pipeline_compile.go
@@ -2,6 +2,7 @@
 //
 // Use of this source code is governed by the LICENSE file in this repository.
 
+// nolint: dupl // ignore similar code among actions
 package action
 
 import (

--- a/action/pipeline_expand.go
+++ b/action/pipeline_expand.go
@@ -2,6 +2,7 @@
 //
 // Use of this source code is governed by the LICENSE file in this repository.
 
+// nolint: dupl // ignore similar code among actions
 package action
 
 import (

--- a/action/pipeline_view.go
+++ b/action/pipeline_view.go
@@ -2,6 +2,7 @@
 //
 // Use of this source code is governed by the LICENSE file in this repository.
 
+// nolint: dupl // ignore similar code among actions
 package action
 
 import (

--- a/action/repo/add.go
+++ b/action/repo/add.go
@@ -2,10 +2,12 @@
 //
 // Use of this source code is governed by the LICENSE file in this repository.
 
+// nolint: dupl // ignore similar code among actions
 package repo
 
 import (
 	"fmt"
+
 	"github.com/go-vela/cli/internal/output"
 
 	"github.com/go-vela/sdk-go/vela"

--- a/action/repo/chown.go
+++ b/action/repo/chown.go
@@ -2,6 +2,7 @@
 //
 // Use of this source code is governed by the LICENSE file in this repository.
 
+// nolint: dupl // ignore similar code among actions
 package repo
 
 import (

--- a/action/repo/remove.go
+++ b/action/repo/remove.go
@@ -2,6 +2,7 @@
 //
 // Use of this source code is governed by the LICENSE file in this repository.
 
+// nolint: dupl // ignore similar code among actions
 package repo
 
 import (

--- a/action/repo/repair.go
+++ b/action/repo/repair.go
@@ -2,6 +2,7 @@
 //
 // Use of this source code is governed by the LICENSE file in this repository.
 
+// nolint: dupl // ignore similar code among actions
 package repo
 
 import (

--- a/action/repo/table.go
+++ b/action/repo/table.go
@@ -49,6 +49,7 @@ func table(repos *[]library.Repo) error {
 	for _, r := range *repos {
 		logrus.Tracef("adding repo %s to repo table", r.GetFullName())
 
+		// nolint: gosec // ignore memory aliasing
 		e := strings.Join(events(&r), ",")
 
 		// add a row to the table with the specified values
@@ -95,6 +96,7 @@ func wideTable(repos *[]library.Repo) error {
 	for _, r := range *repos {
 		logrus.Tracef("adding repo %s to wide repo table", r.GetFullName())
 
+		// nolint: gosec // ignore memory aliasing
 		e := strings.Join(events(&r), ",")
 
 		// add a row to the table with the specified values

--- a/action/repo/update.go
+++ b/action/repo/update.go
@@ -2,10 +2,12 @@
 //
 // Use of this source code is governed by the LICENSE file in this repository.
 
+// nolint: dupl // ignore similar code among actions
 package repo
 
 import (
 	"fmt"
+
 	"github.com/go-vela/cli/internal/output"
 
 	"github.com/go-vela/sdk-go/vela"

--- a/action/repo_add.go
+++ b/action/repo_add.go
@@ -2,6 +2,7 @@
 //
 // Use of this source code is governed by the LICENSE file in this repository.
 
+// nolint: dupl // ignore similar code among actions
 package action
 
 import (
@@ -112,6 +113,7 @@ var RepoAdd = &cli.Command{
 			Usage:   "format the output in json, spew or yaml",
 		},
 	},
+	// nolint: lll // ignore long line length due to flags
 	CustomHelpTemplate: fmt.Sprintf(`%s
 EXAMPLES:
   1. Add a repository with push and pull request enabled.

--- a/action/repo_chown.go
+++ b/action/repo_chown.go
@@ -2,6 +2,7 @@
 //
 // Use of this source code is governed by the LICENSE file in this repository.
 
+// nolint: dupl // ignore similar code among actions
 package action
 
 import (

--- a/action/repo_remove.go
+++ b/action/repo_remove.go
@@ -2,6 +2,7 @@
 //
 // Use of this source code is governed by the LICENSE file in this repository.
 
+// nolint: dupl // ignore similar code among actions
 package action
 
 import (

--- a/action/repo_repair.go
+++ b/action/repo_repair.go
@@ -2,6 +2,7 @@
 //
 // Use of this source code is governed by the LICENSE file in this repository.
 
+// nolint: dupl // ignore similar code among actions
 package action
 
 import (

--- a/action/repo_update.go
+++ b/action/repo_update.go
@@ -2,6 +2,7 @@
 //
 // Use of this source code is governed by the LICENSE file in this repository.
 
+// nolint: dupl // ignore similar code among actions
 package action
 
 import (
@@ -112,6 +113,7 @@ var RepoUpdate = &cli.Command{
 			Usage:   "format the output in json, spew or yaml",
 		},
 	},
+	// nolint: lll // ignore long line length due to flags
 	CustomHelpTemplate: fmt.Sprintf(`%s
 EXAMPLES:
   1. Update a repository with push and pull request enabled.

--- a/action/secret/add.go
+++ b/action/secret/add.go
@@ -2,6 +2,7 @@
 //
 // Use of this source code is governed by the LICENSE file in this repository.
 
+// nolint: dupl // ignore similar code among actions
 package secret
 
 import (

--- a/action/secret/table.go
+++ b/action/secret/table.go
@@ -51,6 +51,8 @@ func table(secrets *[]library.Secret) error {
 		logrus.Tracef("adding secret %s to secret table", s.GetName())
 
 		// calculate the key for the secret
+		//
+		// nolint: gosec // ignore memory aliasing
 		k := key(&s)
 
 		// add a row to the table with the specified values
@@ -104,6 +106,8 @@ func wideTable(secrets *[]library.Secret) error {
 		i := strings.Join(s.GetImages(), ",")
 
 		// calculate the key for the secret
+		//
+		// nolint: gosec // ignore memory aliasing
 		k := key(&s)
 
 		// add a row to the table with the specified values

--- a/action/secret/update.go
+++ b/action/secret/update.go
@@ -2,6 +2,7 @@
 //
 // Use of this source code is governed by the LICENSE file in this repository.
 
+// nolint: dupl // ignore similar code among actions
 package secret
 
 import (

--- a/action/secret_add.go
+++ b/action/secret_add.go
@@ -113,6 +113,7 @@ var SecretAdd = &cli.Command{
 			Usage:   "format the output in json, spew or yaml",
 		},
 	},
+	// nolint: lll // ignore long line length due to flags
 	CustomHelpTemplate: fmt.Sprintf(`%s
 EXAMPLES:
   1. Add a repository secret.
@@ -143,6 +144,8 @@ DOCUMENTATION:
 // helper function to capture the provided
 // input and create the object used to
 // create a secret.
+//
+// nolint: dupl // ignore similar code among actions
 func secretAdd(c *cli.Context) error {
 	// load variables from the config file
 	err := load(c)

--- a/action/secret_get.go
+++ b/action/secret_get.go
@@ -89,6 +89,7 @@ var SecretGet = &cli.Command{
 			Value:   10,
 		},
 	},
+	// nolint: lll // ignore long line length due to flags
 	CustomHelpTemplate: fmt.Sprintf(`%s
 EXAMPLES:
   1. Get repository secret details.

--- a/action/secret_remove.go
+++ b/action/secret_remove.go
@@ -2,6 +2,7 @@
 //
 // Use of this source code is governed by the LICENSE file in this repository.
 
+// nolint: dupl // ignore similar code among actions
 package action
 
 import (
@@ -77,6 +78,7 @@ var SecretRemove = &cli.Command{
 			Usage:   "format the output in json, spew or yaml",
 		},
 	},
+	// nolint: lll // ignore long line length due to flags
 	CustomHelpTemplate: fmt.Sprintf(`%s
 EXAMPLES:
   1. Remove repository secret details.

--- a/action/secret_update.go
+++ b/action/secret_update.go
@@ -108,6 +108,7 @@ var SecretUpdate = &cli.Command{
 			Usage:   "Print the output in default, yaml or json format",
 		},
 	},
+	// nolint: lll // ignore long line length due to flags
 	CustomHelpTemplate: fmt.Sprintf(`%s
 EXAMPLES:
   1. Update a repository secret.
@@ -138,6 +139,8 @@ DOCUMENTATION:
 // helper function to capture the provided
 // input and create the object used to
 // modify a secret.
+//
+// nolint: dupl // ignore similar code among actions
 func secretUpdate(c *cli.Context) error {
 	// load variables from the config file
 	err := load(c)

--- a/action/secret_view.go
+++ b/action/secret_view.go
@@ -2,6 +2,7 @@
 //
 // Use of this source code is governed by the LICENSE file in this repository.
 
+// nolint: dupl // ignore similar code among actions
 package action
 
 import (
@@ -77,6 +78,7 @@ var SecretView = &cli.Command{
 			Usage:   "format the output in json, spew or yaml",
 		},
 	},
+	// nolint: lll // ignore long line length due to flags
 	CustomHelpTemplate: fmt.Sprintf(`%s
 EXAMPLES:
   1. View repository secret details.

--- a/action/service/table.go
+++ b/action/service/table.go
@@ -53,6 +53,8 @@ func table(services *[]library.Service) error {
 		logrus.Tracef("adding service %d to service table", s.GetNumber())
 
 		// calculate duration based off the service timestamps
+		//
+		// nolint: gosec // ignore memory aliasing
 		d := duration(&s)
 
 		// add a row to the table with the specified values
@@ -100,6 +102,8 @@ func wideTable(services *[]library.Service) error {
 		logrus.Tracef("adding service %d to wide service table", s.GetNumber())
 
 		// calculate duration based off the service timestamps
+		//
+		// nolint: gosec // ignore memory aliasing
 		d := duration(&s)
 
 		// calculate created timestamp in human readable form

--- a/action/service_view.go
+++ b/action/service_view.go
@@ -83,6 +83,8 @@ DOCUMENTATION:
 // helper function to capture the provided
 // input and create the object used to
 // inspect a service.
+//
+// nolint: dupl // ignore similar code among actions
 func serviceView(c *cli.Context) error {
 	// load variables from the config file
 	err := load(c)

--- a/action/step/table.go
+++ b/action/step/table.go
@@ -53,6 +53,8 @@ func table(steps *[]library.Step) error {
 		logrus.Tracef("adding step %d to step table", s.GetNumber())
 
 		// calculate duration based off the step timestamps
+		//
+		// nolint: gosec // ignore memory aliasing
 		d := duration(&s)
 
 		// add a row to the table with the specified values
@@ -100,6 +102,8 @@ func wideTable(steps *[]library.Step) error {
 		logrus.Tracef("adding step %d to wide step table", s.GetNumber())
 
 		// calculate duration based off the step timestamps
+		//
+		// nolint: gosec // ignore memory aliasing
 		d := duration(&s)
 
 		// calculate created timestamp in human readable form

--- a/action/step_view.go
+++ b/action/step_view.go
@@ -83,6 +83,8 @@ DOCUMENTATION:
 // helper function to capture the provided
 // input and create the object used to
 // inspect a step.
+//
+// nolint: dupl // ignore similar code among actions
 func stepView(c *cli.Context) error {
 	// load variables from the config file
 	err := load(c)

--- a/cmd/vela-cli/main.go
+++ b/cmd/vela-cli/main.go
@@ -18,6 +18,7 @@ import (
 	"github.com/urfave/cli/v2"
 )
 
+// nolint: funlen // ignore function length due to flags
 func main() {
 	app := cli.NewApp()
 

--- a/internal/internal.go
+++ b/internal/internal.go
@@ -9,7 +9,7 @@ package internal
 //   * https://golang.org/doc/go1.4#internalpackages
 //   * https://docs.google.com/document/d/1e8kOo3r51b2BWtTs_1uADIA5djfXhPT36s6eHVRIvaU/edit
 
-// API flag keys
+// API flag keys.
 const (
 	// FlagAPIAddress defines the key for the
 	// flag when setting the API address.
@@ -34,14 +34,14 @@ const (
 	FlagAPIVersion = "api.version"
 )
 
-// build flag keys
+// build flag keys.
 const (
 	// FlagBuild defines the key for the
 	// flag when setting the build.
 	FlagBuild = "build"
 )
 
-// generic flag keys
+// generic flag keys.
 const (
 	// FlagConfig defines the key for the
 	// flag when setting the config.
@@ -52,14 +52,14 @@ const (
 	FlagOutput = "output"
 )
 
-// log flag keys
+// log flag keys.
 const (
 	// FlagLogLevel defines the key for the
 	// flag when setting the log level.
 	FlagLogLevel = "log.level"
 )
 
-// pagination flag keys
+// pagination flag keys.
 const (
 	// FlagPage defines the key for the
 	// flag when setting the page.
@@ -70,7 +70,7 @@ const (
 	FlagPerPage = "per.page"
 )
 
-// repository flag keys
+// repository flag keys.
 const (
 	// FlagOrg defines the key for the
 	// flag when setting the org.
@@ -81,7 +81,7 @@ const (
 	FlagRepo = "repo"
 )
 
-// secret flag keys
+// secret flag keys.
 const (
 	// FlagSecretEngine defines the key for the
 	// flag when setting the secret engine.
@@ -92,14 +92,14 @@ const (
 	FlagSecretType = "secret.type"
 )
 
-// service flag keys
+// service flag keys.
 const (
 	// FlagService defines the key for the
 	// flag when setting the service.
 	FlagService = "service"
 )
 
-// step flag keys
+// step flag keys.
 const (
 	// FlagStep defines the key for the
 	// flag when setting the step.

--- a/internal/output/driver.go
+++ b/internal/output/driver.go
@@ -4,7 +4,7 @@
 
 package output
 
-// output drivers
+// output drivers.
 const (
 	// DriverStdout defines the driver type
 	// when outputting in stdout format.


### PR DESCRIPTION
Continuation of the efforts from https://github.com/go-vela/mock/pull/76 and https://github.com/go-vela/types/pull/122

* Updating the contributing guide to include fixing linter warnings if any are present
* Skipping the `dupl` and `lll` linters on `*_test.go` files
* Added `nolint` directives across the repo to address any current linter issues