### PR TITLE
feat: adding remote template expansion and validation of local .vela.yml files

### DIFF
--- a/action/pipeline/pipeline.go
+++ b/action/pipeline/pipeline.go
@@ -7,21 +7,22 @@ package pipeline
 // Config represents the configuration necessary
 // to perform pipeline related requests with Vela.
 type Config struct {
-	Action   string
-	Branch   string
-	Comment  string
-	Event    string
-	Tag      string
-	Target   string
-	Org      string
-	Repo     string
-	Ref      string
-	File     string
-	Path     string
-	Type     string
-	Stages   bool
-	Template bool
-	Local    bool
-	Volumes  []string
-	Output   string
+	Action      string
+	Branch      string
+	Comment     string
+	Event       string
+	Tag         string
+	Target      string
+	Org         string
+	Repo        string
+	Ref         string
+	RawPipeline []byte
+	File        string
+	Path        string
+	Type        string
+	Stages      bool
+	Template    bool
+	Local       bool
+	Volumes     []string
+	Output      string
 }

--- a/action/pipeline/validate.go
+++ b/action/pipeline/validate.go
@@ -145,7 +145,6 @@ func (c *Config) ValidateRemote(client *vela.Client) error {
 		}
 		p := string(bodyBytes)
 		pipeline = &p
-
 	} else {
 		// We're only in here if we're pulling the pipeline externally
 

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/go-vela/cli
 
 go 1.15
 
+replace github.com/go-vela/sdk-go => github.com/GregoryDosh/sdk-go v0.8.2-0.20210714213805-e3b693eeac93
+
 require (
 	github.com/Masterminds/semver/v3 v3.1.1
 	github.com/buildkite/yaml v0.0.0-20181016232759-0caa5f0796e3

--- a/go.sum
+++ b/go.sum
@@ -42,6 +42,8 @@ github.com/Azure/go-autorest/logger v0.2.0/go.mod h1:T9E3cAhj2VqvPOtCYAvby9aBXkZ
 github.com/Azure/go-autorest/tracing v0.6.0/go.mod h1:+vhtPC754Xsa23ID7GlGsrdKBpUA79WCAKPPZVC2DeU=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
+github.com/GregoryDosh/sdk-go v0.8.2-0.20210714213805-e3b693eeac93 h1:y9xN9ZZnSjYPSMv6YFhRM9xYGc8VlLVr8vn5TdZ5ytM=
+github.com/GregoryDosh/sdk-go v0.8.2-0.20210714213805-e3b693eeac93/go.mod h1:CTNVI4j/nlupUMG1EOV3bG3vBZeu7dokwWIsNA0pPaE=
 github.com/Masterminds/goutils v1.1.1 h1:5nUrii3FMTL5diU80unEVvNevw1nH4+ZV4DSLVJLSYI=
 github.com/Masterminds/goutils v1.1.1/go.mod h1:8cTjp+g8YejhMuvIA5y2vz3BpJxksy863GQaJW2MFNU=
 github.com/Masterminds/semver/v3 v3.1.1 h1:hLg3sBzpNErnxhQtUy/mmLR2I9foDujNK030IGemrRc=
@@ -148,8 +150,6 @@ github.com/go-vela/pkg-executor v0.8.1 h1:x2nD+mlBw7IJtNp3UaTaB7d9HRJ99VL6sheEzw
 github.com/go-vela/pkg-executor v0.8.1/go.mod h1:s0T+g7nRUD/cVrgr+aAVQ7yPPmNgACBg2d9sG+h1suQ=
 github.com/go-vela/pkg-runtime v0.8.1 h1:2xA4soRtpipF/OOJeK18pQQOInTaqyXLOnwgDkWcLLU=
 github.com/go-vela/pkg-runtime v0.8.1/go.mod h1:+tNkePpoyWY5CJYEwvkCkI7W93b0BuWKM6gQ9Wz+Pos=
-github.com/go-vela/sdk-go v0.8.1 h1:0goUbmVVuTOqU8bdhHkO6ASCAkZqEFdN5/6YRM0Zv6I=
-github.com/go-vela/sdk-go v0.8.1/go.mod h1:CTNVI4j/nlupUMG1EOV3bG3vBZeu7dokwWIsNA0pPaE=
 github.com/go-vela/types v0.8.2 h1:XM5fgHfbAOmIk5zzppjh4u1KsC3auTibsEoVfUZs5pc=
 github.com/go-vela/types v0.8.2/go.mod h1:tKk+FpEAv+BTMr9CL3Wed6tMy5IqyOCJpRTKZI88yDc=
 github.com/gogo/protobuf v1.3.1/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=


### PR DESCRIPTION
As part of https://github.com/go-vela/server/pull/448, this aims to add a new boolean flag to the CLI to support a local .vela.yml file to be supplied and sent off to the remote Vela server for template expansion and validation.

This is pretty rough as the control flow was hacked in. Could use some suggestions and naming changes. This is NOT ready for a merge just yet.

It requires some small changes to https://github.com/go-vela/sdk-go/pull/108 as well. Mostly just to add in a new service call to hit the different server endpoint. So for now the go.mod & go.sum are updated to point at the temporary dependency but that'd be removed before merging this in.