### PR TITLE
feat(pipeline): allow setting type

### DIFF
--- a/action/pipeline/exec.go
+++ b/action/pipeline/exec.go
@@ -53,6 +53,7 @@ func (c *Config) Exec(client compiler.Engine) error {
 	r.SetOrg(c.Org)
 	r.SetName(c.Repo)
 	r.SetFullName(fmt.Sprintf("%s/%s", c.Org, c.Repo))
+	r.SetPipelineType(c.PipelineType)
 
 	logrus.Tracef("compiling pipeline %s", path)
 

--- a/action/pipeline/pipeline.go
+++ b/action/pipeline/pipeline.go
@@ -7,21 +7,22 @@ package pipeline
 // Config represents the configuration necessary
 // to perform pipeline related requests with Vela.
 type Config struct {
-	Action   string
-	Branch   string
-	Comment  string
-	Event    string
-	Tag      string
-	Target   string
-	Org      string
-	Repo     string
-	Ref      string
-	File     string
-	Path     string
-	Type     string
-	Stages   bool
-	Template bool
-	Local    bool
-	Volumes  []string
-	Output   string
+	Action       string
+	Branch       string
+	Comment      string
+	Event        string
+	Tag          string
+	Target       string
+	Org          string
+	Repo         string
+	Ref          string
+	File         string
+	Path         string
+	Type         string
+	Stages       bool
+	Template     bool
+	Local        bool
+	Volumes      []string
+	Output       string
+	PipelineType string
 }

--- a/action/pipeline/validate.go
+++ b/action/pipeline/validate.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/go-vela/cli/internal/output"
 	"github.com/go-vela/sdk-go/vela"
+	"github.com/go-vela/types/library"
 
 	"github.com/go-vela/compiler/compiler"
 
@@ -94,6 +95,9 @@ func (c *Config) ValidateLocal(client compiler.Engine) error {
 	}
 
 	logrus.Tracef("parsing pipeline %s", path)
+
+	// set pipelineType within client
+	client.WithRepo(&library.Repo{PipelineType: &c.PipelineType})
 
 	// parse the object into a pipeline
 	pipeline, err := client.Parse(path)

--- a/action/pipeline/validate.go
+++ b/action/pipeline/validate.go
@@ -11,12 +11,8 @@ import (
 
 	"github.com/go-vela/cli/internal/output"
 	"github.com/go-vela/sdk-go/vela"
-	"github.com/go-vela/types/constants"
-	"github.com/go-vela/types/yaml"
 
 	"github.com/go-vela/compiler/compiler"
-	"github.com/go-vela/compiler/template/native"
-	"github.com/go-vela/compiler/template/starlark"
 
 	"github.com/sirupsen/logrus"
 )
@@ -99,32 +95,10 @@ func (c *Config) ValidateLocal(client compiler.Engine) error {
 
 	logrus.Tracef("parsing pipeline %s", path)
 
-	var pipeline *yaml.Build
-
 	// parse the object into a pipeline
-	parsedRaw, err := client.ParseRaw(path)
+	pipeline, err := client.Parse(path)
 	if err != nil {
 		return err
-	}
-
-	switch c.PipelineType {
-	case constants.PipelineTypeGo:
-		// expand the base configuration
-		pipeline, err = native.RenderBuild(parsedRaw, nil)
-		if err != nil {
-			return err
-		}
-	case constants.PipelineTypeStarlark:
-		// expand the base configuration
-		pipeline, err = starlark.RenderBuild(parsedRaw, nil)
-		if err != nil {
-			return err
-		}
-	default:
-		pipeline, err = client.Parse(parsedRaw)
-		if err != nil {
-			return err
-		}
 	}
 
 	logrus.Tracef("validating pipeline %s", path)

--- a/action/pipeline/validate.go
+++ b/action/pipeline/validate.go
@@ -11,8 +11,12 @@ import (
 
 	"github.com/go-vela/cli/internal/output"
 	"github.com/go-vela/sdk-go/vela"
+	"github.com/go-vela/types/constants"
+	"github.com/go-vela/types/yaml"
 
 	"github.com/go-vela/compiler/compiler"
+	"github.com/go-vela/compiler/template/native"
+	"github.com/go-vela/compiler/template/starlark"
 
 	"github.com/sirupsen/logrus"
 )
@@ -95,10 +99,32 @@ func (c *Config) ValidateLocal(client compiler.Engine) error {
 
 	logrus.Tracef("parsing pipeline %s", path)
 
+	var pipeline *yaml.Build
+
 	// parse the object into a pipeline
-	pipeline, err := client.Parse(path)
+	parsedRaw, err := client.ParseRaw(path)
 	if err != nil {
 		return err
+	}
+
+	switch c.PipelineType {
+	case constants.PipelineTypeGo:
+		// expand the base configuration
+		pipeline, err = native.RenderBuild(parsedRaw, nil)
+		if err != nil {
+			return err
+		}
+	case constants.PipelineTypeStarlark:
+		// expand the base configuration
+		pipeline, err = starlark.RenderBuild(parsedRaw, nil)
+		if err != nil {
+			return err
+		}
+	default:
+		pipeline, err = client.Parse(parsedRaw)
+		if err != nil {
+			return err
+		}
 	}
 
 	logrus.Tracef("validating pipeline %s", path)

--- a/action/pipeline_exec.go
+++ b/action/pipeline_exec.go
@@ -10,6 +10,7 @@ import (
 	"github.com/go-vela/cli/action/pipeline"
 	"github.com/go-vela/cli/internal"
 	"github.com/go-vela/compiler/compiler/native"
+	"github.com/go-vela/types/constants"
 
 	"github.com/urfave/cli/v2"
 )
@@ -107,6 +108,13 @@ var PipelineExec = &cli.Command{
 			Aliases: []string{"r"},
 			Usage:   "provide the repository for the pipeline",
 		},
+		&cli.StringFlag{
+			EnvVars: []string{"VELA_PIPELINE_TYPE", "PIPELINE_TYPE"},
+			Name:    "pipeline-type",
+			Aliases: []string{"pt"},
+			Usage:   "type of pipeline for the compiler to render",
+			Value:   constants.PipelineTypeYAML,
+		},
 	},
 	CustomHelpTemplate: fmt.Sprintf(`%s
 EXAMPLES:
@@ -122,6 +130,8 @@ EXAMPLES:
     $ {{.HelpName}} --volume /tmp/foo.txt:/tmp/foo.txt:ro
   6. Execute a local Vela pipeline with a writeable local volume.
     $ {{.HelpName}} --volume /tmp/bar.txt:/tmp/bar.txt:rw
+  7. Execute a local Vela pipeline with type of go
+    $ {{.HelpName}}  --pipeline-type go
 
 DOCUMENTATION:
 
@@ -143,18 +153,19 @@ func pipelineExec(c *cli.Context) error {
 	//
 	// https://pkg.go.dev/github.com/go-vela/cli/action/pipeline?tab=doc#Config
 	p := &pipeline.Config{
-		Action:  execAction,
-		Branch:  c.String("branch"),
-		Comment: c.String("comment"),
-		Event:   c.String("event"),
-		Tag:     c.String("tag"),
-		Target:  c.String("target"),
-		Org:     c.String(internal.FlagOrg),
-		Repo:    c.String(internal.FlagRepo),
-		File:    c.String("file"),
-		Local:   c.Bool("local"),
-		Path:    c.String("path"),
-		Volumes: c.StringSlice("volume"),
+		Action:       execAction,
+		Branch:       c.String("branch"),
+		Comment:      c.String("comment"),
+		Event:        c.String("event"),
+		Tag:          c.String("tag"),
+		Target:       c.String("target"),
+		Org:          c.String(internal.FlagOrg),
+		Repo:         c.String(internal.FlagRepo),
+		File:         c.String("file"),
+		Local:        c.Bool("local"),
+		Path:         c.String("path"),
+		Volumes:      c.StringSlice("volume"),
+		PipelineType: c.String("pipeline-type"),
 	}
 
 	// validate pipeline configuration

--- a/action/pipeline_exec.go
+++ b/action/pipeline_exec.go
@@ -131,7 +131,7 @@ EXAMPLES:
   6. Execute a local Vela pipeline with a writeable local volume.
     $ {{.HelpName}} --volume /tmp/bar.txt:/tmp/bar.txt:rw
   7. Execute a local Vela pipeline with type of go
-    $ {{.HelpName}}  --pipeline-type go
+    $ {{.HelpName}} --pipeline-type go
 
 DOCUMENTATION:
 

--- a/action/pipeline_validate.go
+++ b/action/pipeline_validate.go
@@ -10,6 +10,7 @@ import (
 	"github.com/go-vela/cli/action/pipeline"
 	"github.com/go-vela/cli/internal"
 	"github.com/go-vela/cli/internal/client"
+	"github.com/go-vela/types/constants"
 
 	"github.com/go-vela/compiler/compiler/native"
 
@@ -37,6 +38,13 @@ var PipelineValidate = &cli.Command{
 			Name:    internal.FlagRepo,
 			Aliases: []string{"r"},
 			Usage:   "provide the repository for the pipeline",
+		},
+		&cli.StringFlag{
+			EnvVars: []string{"VELA_PIPELINE_TYPE", "PIPELINE_TYPE"},
+			Name:    "pipeline-type",
+			Aliases: []string{"pt"},
+			Usage:   "type of pipeline for the compiler to render",
+			Value:   constants.PipelineTypeYAML,
 		},
 
 		// Pipeline Flags
@@ -99,13 +107,14 @@ func pipelineValidate(c *cli.Context) error {
 	//
 	// https://pkg.go.dev/github.com/go-vela/cli/action/pipeline?tab=doc#Config
 	p := &pipeline.Config{
-		Action:   validateAction,
-		Org:      c.String(internal.FlagOrg),
-		Repo:     c.String(internal.FlagRepo),
-		File:     c.String("file"),
-		Path:     c.String("path"),
-		Ref:      c.String("ref"),
-		Template: c.Bool("template"),
+		Action:       validateAction,
+		Org:          c.String(internal.FlagOrg),
+		Repo:         c.String(internal.FlagRepo),
+		File:         c.String("file"),
+		Path:         c.String("path"),
+		Ref:          c.String("ref"),
+		Template:     c.Bool("template"),
+		PipelineType: c.String("pipeline-type"),
 	}
 
 	// validate pipeline configuration

--- a/action/pipeline_validate_test.go
+++ b/action/pipeline_validate_test.go
@@ -31,6 +31,7 @@ func TestAction_PipelineValidate(t *testing.T) {
 	fullSet.String("org", "github", "doc")
 	fullSet.String("repo", "octocat", "doc")
 	fullSet.String("output", "json", "doc")
+	fullSet.String("pipeline-type", "yaml", "doc")
 
 	// setup flags
 	localSet := flag.NewFlagSet("test", 0)

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,5 @@
 module github.com/go-vela/cli
 
-replace github.com/go-vela/compiler => github.com/JordanSussman/compiler v0.1.3-0.20210726211437-20142829e99a
-
 go 1.15
 
 require (
@@ -11,7 +9,7 @@ require (
 	github.com/davecgh/go-spew v1.1.1
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/dustin/go-humanize v1.0.0
-	github.com/go-vela/compiler v0.8.1
+	github.com/go-vela/compiler v0.8.2-0.20210728151243-38af4aebce57
 	github.com/go-vela/mock v0.8.1
 	github.com/go-vela/pkg-executor v0.8.1
 	github.com/go-vela/pkg-runtime v0.8.1

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,7 @@
 module github.com/go-vela/cli
 
+replace github.com/go-vela/compiler => github.com/JordanSussman/compiler v0.1.3-0.20210726211437-20142829e99a
+
 go 1.15
 
 require (
@@ -14,7 +16,7 @@ require (
 	github.com/go-vela/pkg-executor v0.8.1
 	github.com/go-vela/pkg-runtime v0.8.1
 	github.com/go-vela/sdk-go v0.8.1
-	github.com/go-vela/types v0.8.3-0.20210709135941-cea3e4e5d4a9
+	github.com/go-vela/types v0.8.3-0.20210726122150-0eaf6091307b
 	github.com/gosuri/uitable v0.0.4
 	github.com/lunixbochs/vtclean v1.0.0 // indirect
 	github.com/manifoldco/promptui v0.8.0

--- a/go.sum
+++ b/go.sum
@@ -42,8 +42,6 @@ github.com/Azure/go-autorest/logger v0.2.0/go.mod h1:T9E3cAhj2VqvPOtCYAvby9aBXkZ
 github.com/Azure/go-autorest/tracing v0.6.0/go.mod h1:+vhtPC754Xsa23ID7GlGsrdKBpUA79WCAKPPZVC2DeU=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
-github.com/JordanSussman/compiler v0.1.3-0.20210726211437-20142829e99a h1:s/ol/S3kryZB7GX62YEUKIDj19SMzps1jG6v6sjbq5g=
-github.com/JordanSussman/compiler v0.1.3-0.20210726211437-20142829e99a/go.mod h1:AtXEbPEmH1NLJMaawkQf9WC1x/LDY201vqSb+3DBKko=
 github.com/Masterminds/goutils v1.1.1 h1:5nUrii3FMTL5diU80unEVvNevw1nH4+ZV4DSLVJLSYI=
 github.com/Masterminds/goutils v1.1.1/go.mod h1:8cTjp+g8YejhMuvIA5y2vz3BpJxksy863GQaJW2MFNU=
 github.com/Masterminds/semver/v3 v3.1.1 h1:hLg3sBzpNErnxhQtUy/mmLR2I9foDujNK030IGemrRc=
@@ -144,6 +142,9 @@ github.com/go-playground/universal-translator v0.17.0 h1:icxd5fm+REJzpZx7ZfpaD87
 github.com/go-playground/universal-translator v0.17.0/go.mod h1:UkSxE5sNxxRwHyU+Scu5vgOQjsIJAF8j9muTVoKLVtA=
 github.com/go-playground/validator/v10 v10.4.1 h1:pH2c5ADXtd66mxoE0Zm9SUhxE20r7aM3F26W0hOn+GE=
 github.com/go-playground/validator/v10 v10.4.1/go.mod h1:nlOn6nFhuKACm19sB/8EGNn9GlaMV7XkbRSipzJ0Ii4=
+github.com/go-vela/compiler v0.8.1/go.mod h1:GjX2zIKqx5zVh9OaCTzzMG99VvphMqWunPRuW0QBNPg=
+github.com/go-vela/compiler v0.8.2-0.20210728151243-38af4aebce57 h1:MeANcKUowNTfspxIL3gH3qeoG2YltphF7oGItxRtZz8=
+github.com/go-vela/compiler v0.8.2-0.20210728151243-38af4aebce57/go.mod h1:AtXEbPEmH1NLJMaawkQf9WC1x/LDY201vqSb+3DBKko=
 github.com/go-vela/mock v0.8.1 h1:NNOukyA6MRAPp59cBZlrKCrl8LSm+Ww9Pa96OpEsYCo=
 github.com/go-vela/mock v0.8.1/go.mod h1:7WebOs2EzrlNzNrwss1r+tRvy0fUoN73YayMvH9+VQg=
 github.com/go-vela/pkg-executor v0.8.1 h1:x2nD+mlBw7IJtNp3UaTaB7d9HRJ99VL6sheEzwChpCQ=
@@ -198,6 +199,7 @@ github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.6 h1:BKbKCqvP6I+rmFHt06ZmyQtvB8xAkWdhFyr0ZUNZcxQ=
 github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-github/v35 v35.3.0/go.mod h1:yWB7uCcVWaUbUP74Aq3whuMySRMatyRmq5U9FTNlbio=
 github.com/google/go-github/v37 v37.0.0 h1:rCspN8/6kB1BAJWZfuafvHhyfIo5fkAulaP/3bOQ/tM=
 github.com/google/go-github/v37 v37.0.0/go.mod h1:LM7in3NmXDrX58GbEHy7FtNLbI2JijX93RnMKvWG3m4=
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
@@ -474,6 +476,7 @@ golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4Iltr
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20191202225959-858c2ad4c8b6/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
+golang.org/x/oauth2 v0.0.0-20210514164344-f6687ab2804c/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
 golang.org/x/oauth2 v0.0.0-20210628180205-a41e5a781914 h1:3B43BWw0xEBsLZ/NO1VALz6fppU3481pik+2Ksv45z8=
 golang.org/x/oauth2 v0.0.0-20210628180205-a41e5a781914/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=

--- a/go.sum
+++ b/go.sum
@@ -42,6 +42,8 @@ github.com/Azure/go-autorest/logger v0.2.0/go.mod h1:T9E3cAhj2VqvPOtCYAvby9aBXkZ
 github.com/Azure/go-autorest/tracing v0.6.0/go.mod h1:+vhtPC754Xsa23ID7GlGsrdKBpUA79WCAKPPZVC2DeU=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
+github.com/JordanSussman/compiler v0.1.3-0.20210726211437-20142829e99a h1:s/ol/S3kryZB7GX62YEUKIDj19SMzps1jG6v6sjbq5g=
+github.com/JordanSussman/compiler v0.1.3-0.20210726211437-20142829e99a/go.mod h1:AtXEbPEmH1NLJMaawkQf9WC1x/LDY201vqSb+3DBKko=
 github.com/Masterminds/goutils v1.1.1 h1:5nUrii3FMTL5diU80unEVvNevw1nH4+ZV4DSLVJLSYI=
 github.com/Masterminds/goutils v1.1.1/go.mod h1:8cTjp+g8YejhMuvIA5y2vz3BpJxksy863GQaJW2MFNU=
 github.com/Masterminds/semver/v3 v3.1.1 h1:hLg3sBzpNErnxhQtUy/mmLR2I9foDujNK030IGemrRc=
@@ -142,8 +144,6 @@ github.com/go-playground/universal-translator v0.17.0 h1:icxd5fm+REJzpZx7ZfpaD87
 github.com/go-playground/universal-translator v0.17.0/go.mod h1:UkSxE5sNxxRwHyU+Scu5vgOQjsIJAF8j9muTVoKLVtA=
 github.com/go-playground/validator/v10 v10.4.1 h1:pH2c5ADXtd66mxoE0Zm9SUhxE20r7aM3F26W0hOn+GE=
 github.com/go-playground/validator/v10 v10.4.1/go.mod h1:nlOn6nFhuKACm19sB/8EGNn9GlaMV7XkbRSipzJ0Ii4=
-github.com/go-vela/compiler v0.8.1 h1:RLabMScVE8FGDlm7S9e5hLFeedFldkFkj45HDfHWU6s=
-github.com/go-vela/compiler v0.8.1/go.mod h1:GjX2zIKqx5zVh9OaCTzzMG99VvphMqWunPRuW0QBNPg=
 github.com/go-vela/mock v0.8.1 h1:NNOukyA6MRAPp59cBZlrKCrl8LSm+Ww9Pa96OpEsYCo=
 github.com/go-vela/mock v0.8.1/go.mod h1:7WebOs2EzrlNzNrwss1r+tRvy0fUoN73YayMvH9+VQg=
 github.com/go-vela/pkg-executor v0.8.1 h1:x2nD+mlBw7IJtNp3UaTaB7d9HRJ99VL6sheEzwChpCQ=
@@ -153,8 +153,8 @@ github.com/go-vela/pkg-runtime v0.8.1/go.mod h1:+tNkePpoyWY5CJYEwvkCkI7W93b0BuWK
 github.com/go-vela/sdk-go v0.8.1 h1:0goUbmVVuTOqU8bdhHkO6ASCAkZqEFdN5/6YRM0Zv6I=
 github.com/go-vela/sdk-go v0.8.1/go.mod h1:CTNVI4j/nlupUMG1EOV3bG3vBZeu7dokwWIsNA0pPaE=
 github.com/go-vela/types v0.8.2/go.mod h1:tKk+FpEAv+BTMr9CL3Wed6tMy5IqyOCJpRTKZI88yDc=
-github.com/go-vela/types v0.8.3-0.20210709135941-cea3e4e5d4a9 h1:XPb8gNIOQEKdA15BcpwTR9Hqy7m/hVhYnIPxG9sGI6M=
-github.com/go-vela/types v0.8.3-0.20210709135941-cea3e4e5d4a9/go.mod h1:gW/Gbw5+ieIOHKicWrrey7wOVj9PxCGxOq1gZH6Fswc=
+github.com/go-vela/types v0.8.3-0.20210726122150-0eaf6091307b h1:RPgfNchGyoYL5WnVszHqRDBMzyFSTS3ngWOJ8a0SsVE=
+github.com/go-vela/types v0.8.3-0.20210726122150-0eaf6091307b/go.mod h1:gW/Gbw5+ieIOHKicWrrey7wOVj9PxCGxOq1gZH6Fswc=
 github.com/gogo/protobuf v1.3.1/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
@@ -194,11 +194,12 @@ github.com/google/go-cmp v0.4.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.6 h1:BKbKCqvP6I+rmFHt06ZmyQtvB8xAkWdhFyr0ZUNZcxQ=
 github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/google/go-github/v35 v35.3.0 h1:fU+WBzuukn0VssbayTT+Zo3/ESKX9JYWjbZTLOTEyho=
-github.com/google/go-github/v35 v35.3.0/go.mod h1:yWB7uCcVWaUbUP74Aq3whuMySRMatyRmq5U9FTNlbio=
+github.com/google/go-github/v37 v37.0.0 h1:rCspN8/6kB1BAJWZfuafvHhyfIo5fkAulaP/3bOQ/tM=
+github.com/google/go-github/v37 v37.0.0/go.mod h1:LM7in3NmXDrX58GbEHy7FtNLbI2JijX93RnMKvWG3m4=
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
 github.com/google/go-querystring v1.1.0 h1:AnCroh3fv4ZBgVIf1Iwtovgjaw/GiKJo8M8yD/fhyJ8=
 github.com/google/go-querystring v1.1.0/go.mod h1:Kcdr2DB4koayq7X8pmAG4sNG59So17icRSOU623lUBU=
@@ -473,8 +474,8 @@ golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4Iltr
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20191202225959-858c2ad4c8b6/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
-golang.org/x/oauth2 v0.0.0-20210514164344-f6687ab2804c h1:pkQiBZBvdos9qq4wBAHqlzuZHEXo07pqV06ef90u1WI=
-golang.org/x/oauth2 v0.0.0-20210514164344-f6687ab2804c/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
+golang.org/x/oauth2 v0.0.0-20210628180205-a41e5a781914 h1:3B43BWw0xEBsLZ/NO1VALz6fppU3481pik+2Ksv45z8=
+golang.org/x/oauth2 v0.0.0-20210628180205-a41e5a781914/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
@@ -529,8 +530,9 @@ golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210225134936-a50acf3fe073/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210319071255-635bc2c9138d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210420072515-93ed5bcd2bfe/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20210423082822-04245dca01da h1:b3NXsE2LusjYGGjL5bxEVZZORm/YEFFrWFjR8eFrw/c=
 golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210426230700-d19ff857e887 h1:dXfMednGJh/SUUFjTLsWJz3P+TQt9qnR11GgeI3vWKs=
+golang.org/x/sys v0.0.0-20210426230700-d19ff857e887/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210220032956-6a3ed077a48d h1:SZxvLBoTP5yHO3Frd4z4vrF+DBX9vMVanchswa69toE=
@@ -713,8 +715,9 @@ honnef.co/go/tools v0.0.1-2020.1.3/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9
 honnef.co/go/tools v0.0.1-2020.1.4/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
 k8s.io/api v0.21.1 h1:94bbZ5NTjdINJEdzOkpS4vdPhkb1VFpTYC9zh43f75c=
 k8s.io/api v0.21.1/go.mod h1:FstGROTmsSHBarKc8bylzXih8BLNYTiS3TZcsoEDg2s=
-k8s.io/apimachinery v0.21.1 h1:Q6XuHGlj2xc+hlMCvqyYfbv3H7SRGn2c8NycxJquDVs=
 k8s.io/apimachinery v0.21.1/go.mod h1:jbreFvJo3ov9rj7eWT7+sYiRx+qZuCYXwWT1bcDswPY=
+k8s.io/apimachinery v0.21.3 h1:3Ju4nvjCngxxMYby0BimUk+pQHPOQp3eCGChk5kfVII=
+k8s.io/apimachinery v0.21.3/go.mod h1:H/IM+5vH9kZRNJ4l3x/fXP/5bOPJaVP/guptnZPeCFI=
 k8s.io/client-go v0.21.1 h1:bhblWYLZKUu+pm50plvQF8WpY6TXdRRtcS/K9WauOj4=
 k8s.io/client-go v0.21.1/go.mod h1:/kEw4RgW+3xnBGzvp9IWxKSNA+lXn3A7AuH3gdOAzLs=
 k8s.io/gengo v0.0.0-20200413195148-3a45101e95ac/go.mod h1:ezvh/TsK7cY6rbqRK0oQQ8IAqLxYwwyPxAX1Pzy0ii0=
@@ -729,7 +732,8 @@ rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8
 rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=
 rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=
 sigs.k8s.io/structured-merge-diff/v4 v4.0.2/go.mod h1:bJZC9H9iH24zzfZ/41RGcq60oK1F7G282QMXDPYydCw=
-sigs.k8s.io/structured-merge-diff/v4 v4.1.0 h1:C4r9BgJ98vrKnnVCjwCSXcWjWe0NKcUQkmzDXZXGwH8=
 sigs.k8s.io/structured-merge-diff/v4 v4.1.0/go.mod h1:bJZC9H9iH24zzfZ/41RGcq60oK1F7G282QMXDPYydCw=
+sigs.k8s.io/structured-merge-diff/v4 v4.1.2 h1:Hr/htKFmJEbtMgS/UD0N+gtgctAqz81t3nu+sPzynno=
+sigs.k8s.io/structured-merge-diff/v4 v4.1.2/go.mod h1:j/nl6xW8vLS49O8YvXW1ocPhZawJtm+Yrr7PPRQ0Vg4=
 sigs.k8s.io/yaml v1.2.0 h1:kr/MCeFWJWTwyaHoR9c8EjH9OumOmoF9YGiZd7lFm/Q=
 sigs.k8s.io/yaml v1.2.0/go.mod h1:yfXDCHCao9+ENCvLSE62v9VSji2MKu5jeNfTrofGhJc=


### PR DESCRIPTION
Allowing setting the pipeline type within the `exec` and `validate` functions.

xref: https://github.com/go-vela/community/issues/326