### PR TITLE
enhance(help): pipeline private github template validation

### DIFF
--- a/action/pipeline_validate.go
+++ b/action/pipeline_validate.go
@@ -101,6 +101,7 @@ var PipelineValidate = &cli.Command{
 			Usage:   "github url, used by compiler, for pulling registry templates",
 		},
 	},
+	// nolint:lll // help messages is pushing over limit
 	CustomHelpTemplate: fmt.Sprintf(`%s
 EXAMPLES:
   1. Validate a local Vela pipeline.


### PR DESCRIPTION
fixes numbering and improves messaging for validating templates, especially in the instance where templates are sourced from a private Github instance.

there probably should be a proper fix, since **not** specifying compiler token and url for validating internally sourced templates causes a nil pointer reference error. we determine template source too late to know whether we need these parameters.