### PR TITLE
fix(actions): pin binary actions for prerelease

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -27,12 +27,12 @@ jobs:
         fetch-depth: 0
 
     - name: build
-      uses: skx/github-action-build@master
+      uses: skx/github-action-build@release-0.6.1
       with:
         builder: ./release.sh
 
     - name: upload
-      uses: skx/github-action-publish-binaries@master
+      uses: skx/github-action-publish-binaries@release-1.3
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:


### PR DESCRIPTION
This pins some custom Actions in the [prerelease workflow](https://github.com/go-vela/cli/blob/master/.github/workflows/prerelease.yml):

* https://github.com/skx/github-action-build/releases/tag/release-0.6.1
* https://github.com/skx/github-action-publish-binaries/releases/tag/release-1.3

Recently, we've been having intermittent issues with these Actions successfully completing.

Changes have been introduced that could be causing this behavior.

By pinning to an old release, we should remove the potential for these to fail based off new changes.