### PR TITLE
fix: check if local pipeline exists

### DIFF
--- a/action/pipeline/validate.go
+++ b/action/pipeline/validate.go
@@ -82,6 +82,12 @@ func (c *Config) ValidateLocal(client compiler.Engine) error {
 		path = filepath.Join(c.Path, c.File)
 	}
 
+	// check if full path to pipeline file exists
+	_, err = os.Stat(path)
+	if err != nil {
+		return fmt.Errorf("unable to find pipeline %s: %v", path, err)
+	}
+
 	path, err = validateFile(path)
 	if err != nil {
 		return err


### PR DESCRIPTION
Closes https://github.com/go-vela/community/issues/411

Related to https://github.com/go-vela/cli/pull/256

This updates the `vela validate pipeline` command to check if the local pipeline exists before attempting to validate it.

Currently, when you run `vela validate pipeline`, some defaults are setup for both the `path` and `file` flags.

For the `path` flag, the CLI will default to looking in the current working directory:

https://github.com/go-vela/cli/blob/afd188309fdd66477b5c267ff73d076ac276065f/action/pipeline/validate.go#L70-L77

For the `file` flag, the CLI will default to looking for a file name `.vela.yml`:

https://github.com/go-vela/cli/blob/afd188309fdd66477b5c267ff73d076ac276065f/action/pipeline_validate.go#L52-L58

This causes an issue if the command is ran with no flags provided and the file doesn't exist in the current working directory.

This will lead to an error message like:

```
FATA[0000] unable to unmarshal yaml: yaml: unmarshal errors:
  line 1: cannot unmarshal !!str `/Users/...` into yaml.Build
```