### PR TITLE
enhance: setting version information

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,14 +18,8 @@ ifndef GITHUB_TAG
 	GITHUB_TAG = $(shell git describe --tag --abbrev=0)
 endif
 
-# check if a go version is already set
-ifndef GOLANG_VERSION
-	# capture the current go version we build the application from
-	GOLANG_VERSION = $(shell go version | awk '{ print $$3 }')
-endif
-
 # create a list of linker flags for building the golang application
-LD_FLAGS = -X github.com/go-vela/cli/version.Commit=${GITHUB_SHA} -X github.com/go-vela/cli/version.Date=${BUILD_DATE} -X github.com/go-vela/cli/version.Go=${GOLANG_VERSION} -X github.com/go-vela/cli/version.Tag=${GITHUB_TAG}
+LD_FLAGS = -X github.com/go-vela/cli/version.Commit=${GITHUB_SHA} -X github.com/go-vela/cli/version.Date=${BUILD_DATE} -X github.com/go-vela/cli/version.Tag=${GITHUB_TAG}
 
 # The `clean` target is intended to clean the workspace
 # and prepare the local changes for submission.

--- a/version/version.go
+++ b/version/version.go
@@ -23,7 +23,7 @@ var (
 	// Date represents the build date information for the package.
 	Date string
 	// Go represents the golang version information for the package.
-	Go string
+	Go = runtime.Version()
 	// OS represents the operating system information for the package.
 	OS = runtime.GOOS
 	// Tag represents the git tag information for the package.

--- a/version/version.go
+++ b/version/version.go
@@ -9,8 +9,8 @@ import (
 	"runtime"
 
 	"github.com/Masterminds/semver/v3"
-
 	"github.com/go-vela/types/version"
+	"github.com/sirupsen/logrus"
 )
 
 var (
@@ -32,9 +32,14 @@ var (
 
 // New creates a new version object for Vela that is used throughout the application.
 func New() *version.Version {
+	// check if a semantic tag was provided
 	if len(Tag) == 0 {
+		logrus.Warningf("no semantic tag provided - defaulting to v0.0.0")
+
+		// set a fallback default for the tag
 		Tag = "v0.0.0"
 	}
+
 	v, err := semver.NewVersion(Tag)
 	if err != nil {
 		fmt.Println(fmt.Errorf("unable to parse semantic version for %s: %v", Tag, err))


### PR DESCRIPTION
This first part is updating the version output to provide a log message when the fallback value is used for the semantic tag.

This message should be displayed if the tag info isn't captured properly:

https://github.com/go-vela/cli/blob/0222b053482f3212684e7e6e1f45a1c1a41740d9/Makefile#L15-L19

The second part is using Go's `runtime.Version()` function to capture the version of `go` the app is built with:

https://pkg.go.dev/runtime#Version

Since we're relying on that function from the `runtime` library, we no longer need to capture that info in the `Makefile`.

Previously, we used to run the `go version` command and parse the value from the output:

https://github.com/go-vela/cli/blob/0222b053482f3212684e7e6e1f45a1c1a41740d9/Makefile#L21-L25