### PR TITLE
fix(repo): change sync flags to be consistent with repo package

### DIFF
--- a/command/repo/sync.go
+++ b/command/repo/sync.go
@@ -27,13 +27,13 @@ var CommandSync = &cli.Command{
 		// Repo Flags
 
 		&cli.StringFlag{
-			EnvVars: []string{"VELA_ORG", "BUILD_ORG"},
+			EnvVars: []string{"VELA_ORG", "REPO_ORG"},
 			Name:    internal.FlagOrg,
 			Aliases: []string{"o"},
 			Usage:   "provide the organization for the build",
 		},
 		&cli.StringFlag{
-			EnvVars: []string{"VELA_REPO", "BUILD_REPO"},
+			EnvVars: []string{"VELA_REPO", "REPO_NAME"},
 			Name:    internal.FlagRepo,
 			Aliases: []string{"r"},
 			Usage:   "provide the repository for the build",


### PR DESCRIPTION
When writing the docs for sync, I noticed that these environment variables are not consistent with what repo and orgs are called in the rest of the repo package. Small fix.