### PR TITLE
fix(validate): handle .yaml default file

### DIFF
--- a/action/pipeline/validate.go
+++ b/action/pipeline/validate.go
@@ -83,11 +83,6 @@ func (c *Config) ValidateLocal(client compiler.Engine) error {
 	}
 
 	// check if full path to pipeline file exists
-	_, err = os.Stat(path)
-	if err != nil {
-		return fmt.Errorf("unable to find pipeline %s: %v", path, err)
-	}
-
 	path, err = validateFile(path)
 	if err != nil {
 		return err


### PR DESCRIPTION
fixes the scenario where the default pipeline is named `.vela.yaml` instead of `.vela.yml`. So, if you haven't specified the filename explicitly it will error instead `... .vela.yml: no such file or directory`. It's picking `.vela.yml` because a file wasn't specified. Since we support both `.yml` and `.yaml` by default it probably shouldn't error. The `validateFile` function already accounts for both valid defaults.