### PR TITLE
refactor(action): use resource library.Duration() functions

### DIFF
--- a/action/build/table.go
+++ b/action/build/table.go
@@ -6,17 +6,12 @@ package build
 
 import (
 	"sort"
-	"strings"
 	"time"
 
-	"github.com/go-vela/cli/internal/output"
-
-	"github.com/go-vela/types/constants"
-	"github.com/go-vela/types/library"
-
 	"github.com/dustin/go-humanize"
+	"github.com/go-vela/cli/internal/output"
+	"github.com/go-vela/types/library"
 	"github.com/gosuri/uitable"
-
 	"github.com/sirupsen/logrus"
 )
 
@@ -52,15 +47,10 @@ func table(builds *[]library.Build) error {
 	for _, b := range reverse(*builds) {
 		logrus.Tracef("adding build %d to build table", b.GetNumber())
 
-		// calculate duration based off the build timestamps
-		//
-		// nolint: gosec // ignore memory aliasing
-		d := duration(&b)
-
 		// add a row to the table with the specified values
 		//
 		// https://pkg.go.dev/github.com/gosuri/uitable?tab=doc#Table.AddRow
-		table.AddRow(b.GetNumber(), b.GetStatus(), b.GetEvent(), b.GetBranch(), d)
+		table.AddRow(b.GetNumber(), b.GetStatus(), b.GetEvent(), b.GetBranch(), b.Duration())
 	}
 
 	// output the table in stdout format
@@ -103,11 +93,6 @@ func wideTable(builds *[]library.Build) error {
 	for _, b := range reverse(*builds) {
 		logrus.Tracef("adding build %d to wide build table", b.GetNumber())
 
-		// calculate duration based off the build timestamps
-		//
-		// nolint: gosec // ignore memory aliasing
-		d := duration(&b)
-
 		// calculate created timestamp in human readable form
 		//
 		// https://pkg.go.dev/github.com/dustin/go-humanize?tab=doc#Time
@@ -123,38 +108,13 @@ func wideTable(builds *[]library.Build) error {
 		// https://pkg.go.dev/github.com/gosuri/uitable?tab=doc#Table.AddRow
 		//
 		// nolint: lll // ignore long line length due to number of columns
-		table.AddRow(b.GetNumber(), b.GetStatus(), b.GetEvent(), b.GetBranch(), b.GetCommit(), d, c, f, b.GetAuthor())
+		table.AddRow(b.GetNumber(), b.GetStatus(), b.GetEvent(), b.GetBranch(), b.GetCommit(), b.Duration(), c, f, b.GetAuthor())
 	}
 
 	// output the wide table in stdout format
 	//
 	// https://pkg.go.dev/github.com/go-vela/cli/internal/output?tab=doc#Stdout
 	return output.Stdout(table)
-}
-
-// duration is a helper function to calculate
-// the total duration a build ran for in a
-// more consumable, human readable format.
-func duration(b *library.Build) string {
-	// check if build is in a pending or running state
-	if strings.EqualFold(b.GetStatus(), constants.StatusPending) ||
-		strings.EqualFold(b.GetStatus(), constants.StatusRunning) {
-		// return a default value to display the build is not complete
-		return "..."
-	}
-
-	// capture finished unix timestamp from build
-	f := time.Unix(b.GetFinished(), 0)
-	// capture started unix timestamp from build
-	s := time.Unix(b.GetStarted(), 0)
-
-	// get the duration by subtracting the build
-	// started unix timestamp from the build finished
-	// unix timestamp.
-	d := f.Sub(s)
-
-	// return duration in a human readable form
-	return d.String()
 }
 
 // reverse is a helper function to sort the builds

--- a/action/step/table.go
+++ b/action/step/table.go
@@ -6,17 +6,12 @@ package step
 
 import (
 	"sort"
-	"strings"
 	"time"
 
-	"github.com/go-vela/cli/internal/output"
-
-	"github.com/go-vela/types/constants"
-	"github.com/go-vela/types/library"
-
 	"github.com/dustin/go-humanize"
+	"github.com/go-vela/cli/internal/output"
+	"github.com/go-vela/types/library"
 	"github.com/gosuri/uitable"
-
 	"github.com/sirupsen/logrus"
 )
 
@@ -52,15 +47,10 @@ func table(steps *[]library.Step) error {
 	for _, s := range reverse(*steps) {
 		logrus.Tracef("adding step %d to step table", s.GetNumber())
 
-		// calculate duration based off the step timestamps
-		//
-		// nolint: gosec // ignore memory aliasing
-		d := duration(&s)
-
 		// add a row to the table with the specified values
 		//
 		// https://pkg.go.dev/github.com/gosuri/uitable?tab=doc#Table.AddRow
-		table.AddRow(s.GetNumber(), s.GetName(), s.GetStatus(), d)
+		table.AddRow(s.GetNumber(), s.GetName(), s.GetStatus(), s.Duration())
 	}
 
 	// output the table in stdout format
@@ -101,11 +91,6 @@ func wideTable(steps *[]library.Step) error {
 	for _, s := range reverse(*steps) {
 		logrus.Tracef("adding step %d to wide step table", s.GetNumber())
 
-		// calculate duration based off the step timestamps
-		//
-		// nolint: gosec // ignore memory aliasing
-		d := duration(&s)
-
 		// calculate created timestamp in human readable form
 		//
 		// https://pkg.go.dev/github.com/dustin/go-humanize?tab=doc#Time
@@ -119,38 +104,13 @@ func wideTable(steps *[]library.Step) error {
 		// add a row to the table with the specified values
 		//
 		// https://pkg.go.dev/github.com/gosuri/uitable?tab=doc#Table.AddRow
-		table.AddRow(s.GetNumber(), s.GetName(), s.GetStatus(), d, c, f)
+		table.AddRow(s.GetNumber(), s.GetName(), s.GetStatus(), s.Duration(), c, f)
 	}
 
 	// output the wide table in stdout format
 	//
 	// https://pkg.go.dev/github.com/go-vela/cli/internal/output?tab=doc#Stdout
 	return output.Stdout(table)
-}
-
-// duration is a helper function to calculate
-// the total duration a step ran for in a
-// more consumable, human readable format.
-func duration(s *library.Step) string {
-	// check if step is in a pending or running state
-	if strings.EqualFold(s.GetStatus(), constants.StatusPending) ||
-		strings.EqualFold(s.GetStatus(), constants.StatusRunning) {
-		// return a default value to display the step is not complete
-		return "..."
-	}
-
-	// capture finished unix timestamp from step
-	f := time.Unix(s.GetFinished(), 0)
-	// capture started unix timestamp from step
-	st := time.Unix(s.GetStarted(), 0)
-
-	// get the duration by subtracting the step
-	// started unix timestamp from the step finished
-	// unix timestamp.
-	d := f.Sub(st)
-
-	// return duration in a human readable form
-	return d.String()
 }
 
 // reverse is a helper function to sort the steps


### PR DESCRIPTION
Based off of https://github.com/go-vela/types/pull/222 and https://github.com/go-vela/types/pull/227

This change uses the `<resource>.Duration()` functions from the `github.com/go-vela/types/library` package:

* https://pkg.go.dev/github.com/go-vela/types/library#Build.Duration
* https://pkg.go.dev/github.com/go-vela/types/library#Service.Duration
* https://pkg.go.dev/github.com/go-vela/types/library#Step.Duration

Also included in this change is the removal of the `duration()` helper functions for each resource.