### PR TITLE
fix(hook): remove 'h' from alias

### DIFF
--- a/command/hook/view.go
+++ b/command/hook/view.go
@@ -43,7 +43,7 @@ var CommandView = &cli.Command{
 		&cli.IntFlag{
 			EnvVars: []string{"VELA_HOOK", "HOOK_NUMBER"},
 			Name:    "hook",
-			Aliases: []string{"h", "number", "hn"},
+			Aliases: []string{"number", "hn"},
 			Usage:   "provide the number for the hook",
 		},
 


### PR DESCRIPTION
`h` is a reserved alias for `--help`

leaving this in causes a panic:
```
$ vela view hook --org $VELA_ORG --repo $VELA_REPO --hook $VELA_HOOK
hook flag redefined: h
panic: hook flag redefined: h
```