### PR TITLE
fix(exec): make sure to call StreamBuild

### DIFF
--- a/action/pipeline/exec.go
+++ b/action/pipeline/exec.go
@@ -143,7 +143,7 @@ func (c *Config) Exec(client compiler.Engine) error {
 
 	// log/event streaming
 	go func() {
-		logrus.Info("streaming build logs")
+		logrus.Debug("streaming build logs")
 		// start process to handle StreamRequests
 		// from Steps and Services
 		err = _executor.StreamBuild(ctx)


### PR DESCRIPTION
fixes https://github.com/go-vela/community/issues/655

this essentially mimics https://github.com/go-vela/worker/blob/v0.14.0/cmd/vela-worker/exec.go#L135-L143. we don't have a timeout for local execution, so i didn't introduce another context or timeout.