### PR TITLE
fix(events): use default events set on server

### DIFF
--- a/command/repo/add.go
+++ b/command/repo/add.go
@@ -111,10 +111,6 @@ var CommandAdd = &cli.Command{
 			Name:    "event",
 			Aliases: []string{"e"},
 			Usage:   "webhook event(s) repository responds to",
-			Value: cli.NewStringSlice(
-				constants.EventPush,
-				constants.EventPull,
-			),
 		},
 		&cli.StringFlag{
 			EnvVars: []string{"VELA_PIPELINE_TYPE", "PIPELINE_TYPE"},


### PR DESCRIPTION
default events are dictated by server - don't set defaults events in the CLI when enabling a repository to play nicely with https://github.com/go-vela/server/pull/758