### PR TITLE
feat(log): Support paging on `vela get log`

### DIFF
--- a/action/log/get.go
+++ b/action/log/get.go
@@ -18,10 +18,18 @@ func (c *Config) Get(client *vela.Client) error {
 
 	logrus.Tracef("capturing logs for build %s/%s/%d", c.Org, c.Repo, c.Build)
 
+	// set the pagination options for list of build logs
+	//
+	// https://pkg.go.dev/github.com/go-vela/sdk-go/vela?tab=doc#ListOptions
+	opts := &vela.ListOptions{
+		Page:    c.Page,
+		PerPage: c.PerPage,
+	}
+
 	// send API call to capture a list of build logs
 	//
 	// https://pkg.go.dev/github.com/go-vela/sdk-go/vela?tab=doc#BuildService.GetLogs
-	logs, _, err := client.Build.GetLogs(c.Org, c.Repo, c.Build)
+	logs, _, err := client.Build.GetLogs(c.Org, c.Repo, c.Build, opts)
 	if err != nil {
 		return err
 	}

--- a/action/log/log.go
+++ b/action/log/log.go
@@ -13,5 +13,7 @@ type Config struct {
 	Build   int
 	Service int
 	Step    int
+	Page    int
+	PerPage int
 	Output  string
 }

--- a/command/log/get.go
+++ b/command/log/get.go
@@ -56,6 +56,23 @@ var CommandGet = &cli.Command{
 			Aliases: []string{"op"},
 			Usage:   "format the output in json, spew or yaml",
 		},
+
+		// Pagination Flags
+
+		&cli.IntFlag{
+			EnvVars: []string{"VELA_PAGE", "LOG_PAGE"},
+			Name:    internal.FlagPage,
+			Aliases: []string{"p"},
+			Usage:   "print a specific page of build logs",
+			Value:   1,
+		},
+		&cli.IntFlag{
+			EnvVars: []string{"VELA_PER_PAGE", "LOG_PER_PAGE"},
+			Name:    internal.FlagPerPage,
+			Aliases: []string{"pp"},
+			Usage:   "number of build logs to print per page",
+			Value:   100, // server defaults to 10
+		},
 	},
 	CustomHelpTemplate: fmt.Sprintf(`%s
 EXAMPLES:
@@ -96,11 +113,13 @@ func get(c *cli.Context) error {
 	//
 	// https://pkg.go.dev/github.com/go-vela/cli/action/log?tab=doc#Config
 	l := &log.Config{
-		Action: internal.ActionGet,
-		Org:    c.String(internal.FlagOrg),
-		Repo:   c.String(internal.FlagRepo),
-		Build:  c.Int(internal.FlagBuild),
-		Output: c.String(internal.FlagOutput),
+		Action:  internal.ActionGet,
+		Org:     c.String(internal.FlagOrg),
+		Repo:    c.String(internal.FlagRepo),
+		Build:   c.Int(internal.FlagBuild),
+		Page:    c.Int(internal.FlagPage),
+		PerPage: c.Int(internal.FlagPerPage),
+		Output:  c.String(internal.FlagOutput),
 	}
 
 	// validate log configuration


### PR DESCRIPTION
Adds support for the `page` and `per_page` query parameters in `vela get log` (endpoint `/api/v1/repos/+/+/builds/+/logs`).

The server-side default changed from `per_page=100` to `per_page=10` in https://github.com/go-vela/server/pull/798, so the cli arg here defaults to 100 to maintain the same behavior that users experienced before. But, now they can get additional pages of logs if there are more than 100, or they can lower the per_page amount if they want to see fewer.

Depends on:
- https://github.com/go-vela/server/pull/798
- https://github.com/go-vela/sdk-go/pull/216