### PR TITLE
chore(ci/build): use matrix for builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,10 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        os: [ darwin, linux, windows ]
     
     steps:
     - name: clone
@@ -25,4 +29,4 @@ jobs:
 
     - name: build
       run: |
-        make build
+        make build-${{ matrix.os }}


### PR DESCRIPTION
should add a little speed boost for running the `build` workflow. it will parallelize building for each platform when possible - could even add arch into the mix.

ref: https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs

opportunity to do the same for release builds (on release/tag events). `make build` is baked into the `release.sh` script, so might need a bit of rework.

UPDATE:
comparing the build in this PR with the matrix addition versus another, it looks like we're shaving off almost 10 minutes of build time.

### before
![image](https://github.com/go-vela/cli/assets/49894298/06233910-8886-4a90-b505-bb2756031282)

### after
![image](https://github.com/go-vela/cli/assets/49894298/fb1c322b-0e27-45e8-bc3e-eeda266f33e0)
