### PR TITLE
patch(v0.20.2/secrets): support schedule event for secrets

### DIFF
--- a/action/secret/validate.go
+++ b/action/secret/validate.go
@@ -96,6 +96,8 @@ func (c *Config) Validate() error {
 				fallthrough
 			case constants.EventPush:
 				fallthrough
+			case constants.EventSchedule:
+				fallthrough
 			case constants.EventTag:
 				continue
 			default:

--- a/action/secret/validate_test.go
+++ b/action/secret/validate_test.go
@@ -94,6 +94,20 @@ func TestSecret_Config_Validate(t *testing.T) {
 			},
 		},
 		{
+			failure: false,
+			config: &Config{
+				Action: "add",
+				Engine: "native",
+				Type:   "repo",
+				Org:    "github",
+				Repo:   "octocat",
+				Name:   "foo",
+				Value:  "bar",
+				Events: []string{"comment", "push", "pull_request", "tag", "deployment", "schedule"},
+				Output: "",
+			},
+		},
+		{
 			failure: true,
 			config: &Config{
 				Action: "add",


### PR DESCRIPTION
Preparing patch release for v0.20.2 with these changes: https://github.com/go-vela/cli/pull/475