### PR TITLE
enhance(deploy)!: remove default value for ref in add deployment command

### DIFF
--- a/action/deployment/validate.go
+++ b/action/deployment/validate.go
@@ -28,7 +28,7 @@ func (c *Config) Validate() error {
 	if c.Action == "add" {
 		// check if deployment ref is set
 		if len(c.Ref) == 0 {
-			return fmt.Errorf("no deployment ref provided")
+			logrus.Debug("no ref provided. Using repo default branch...")
 		}
 
 		// check if deployment target is set

--- a/action/deployment/validate.go
+++ b/action/deployment/validate.go
@@ -28,12 +28,12 @@ func (c *Config) Validate() error {
 	if c.Action == "add" {
 		// check if deployment ref is set
 		if len(c.Ref) == 0 {
-			logrus.Debug("no ref provided. Using repo default branch...")
+			logrus.Warn("no deployment ref provided. Using repo default branch")
 		}
 
 		// check if deployment target is set
 		if len(c.Target) == 0 {
-			logrus.Debug("no deployment target provided")
+			logrus.Warn("no deployment target provided")
 		}
 	}
 

--- a/action/deployment/validate.go
+++ b/action/deployment/validate.go
@@ -33,7 +33,7 @@ func (c *Config) Validate() error {
 
 		// check if deployment target is set
 		if len(c.Target) == 0 {
-			return fmt.Errorf("no deployment target provided")
+			logrus.Debug("no deployment target provided")
 		}
 	}
 

--- a/action/deployment/validate_test.go
+++ b/action/deployment/validate_test.go
@@ -48,7 +48,7 @@ func TestDeployment_Config_Validate(t *testing.T) {
 				Output: "",
 			},
 		},
-		{
+		{ // no ref should still be valid
 			failure: false,
 			config: &Config{
 				Action:      "add",
@@ -60,8 +60,8 @@ func TestDeployment_Config_Validate(t *testing.T) {
 				Output:      "",
 			},
 		},
-		{
-			failure: true,
+		{ // no target should still be valid
+			failure: false,
 			config: &Config{
 				Action:      "add",
 				Org:         "github",

--- a/action/deployment/validate_test.go
+++ b/action/deployment/validate_test.go
@@ -49,7 +49,7 @@ func TestDeployment_Config_Validate(t *testing.T) {
 			},
 		},
 		{
-			failure: true,
+			failure: false,
 			config: &Config{
 				Action:      "add",
 				Org:         "github",

--- a/command/deployment/add.go
+++ b/command/deployment/add.go
@@ -50,7 +50,6 @@ var CommandAdd = &cli.Command{
 			Name:    "target",
 			Aliases: []string{"t"},
 			Usage:   "provide the name for the target deployment environment",
-			Value:   "production",
 		},
 		&cli.StringFlag{
 			EnvVars: []string{"VELA_DESCRIPTION", "DEPLOYMENT_DESCRIPTION"},

--- a/command/deployment/add.go
+++ b/command/deployment/add.go
@@ -44,7 +44,6 @@ var CommandAdd = &cli.Command{
 			EnvVars: []string{"VELA_REF", "DEPLOYMENT_REF"},
 			Name:    "ref",
 			Usage:   "provide the reference to deploy - this can be a branch, commit (SHA) or tag",
-			Value:   "refs/heads/master",
 		},
 		&cli.StringFlag{
 			EnvVars: []string{"VELA_TARGET", "DEPLOYMENT_TARGET"},


### PR DESCRIPTION
Closes https://github.com/go-vela/community/issues/423

Made possible by https://github.com/go-vela/server/pull/961

Also removing the default value of `production` as a deployment target. This seems like it could exacerbate a simple mistake if folks forget to provide a target when intending to target a non-prod environment.

Marking this breaking, as potential scripts that depended on those default values (mostly the target, as the ref will be populated with the default branch anyway) will now not work as they used to. 