### PR TITLE
enhance(pipeline/exec): include changeset for ruleset matching

### DIFF
--- a/action/pipeline/exec.go
+++ b/action/pipeline/exec.go
@@ -76,6 +76,7 @@ func (c *Config) Exec(client compiler.Engine) error {
 		Duplicate().
 		WithBuild(b).
 		WithComment(c.Comment).
+		WithFiles(c.FileChangeset).
 		WithLocal(true).
 		WithRepo(r).
 		WithLocalTemplates(c.TemplateFiles).

--- a/action/pipeline/pipeline.go
+++ b/action/pipeline/pipeline.go
@@ -15,6 +15,7 @@ type Config struct {
 	Repo          string
 	Ref           string
 	File          string
+	FileChangeset []string
 	Path          string
 	Type          string
 	Stages        bool

--- a/command/pipeline/exec.go
+++ b/command/pipeline/exec.go
@@ -58,6 +58,12 @@ var CommandExec = &cli.Command{
 			Name:    "target",
 			Usage:   "provide the build target for the pipeline",
 		},
+		&cli.StringSliceFlag{
+			EnvVars: []string{"VELA_FILE_CHANGESET", "FILE_CHANGESET"},
+			Name:    "file-changeset",
+			Aliases: []string{"fcs"},
+			Usage:   "provide a list of files changed for ruleset matching",
+		},
 
 		// Output Flags
 
@@ -259,6 +265,7 @@ func exec(c *cli.Context) error {
 		Org:           c.String(internal.FlagOrg),
 		Repo:          c.String(internal.FlagRepo),
 		File:          c.String("file"),
+		FileChangeset: c.StringSlice("file-changeset"),
 		TemplateFiles: c.StringSlice("template-file"),
 		Local:         c.Bool("local"),
 		Path:          c.String("path"),


### PR DESCRIPTION
`vela exec pipeline` on a step with a `path` rule will never run that step