### PR TITLE
fix(repo): do not have default value for branch

### DIFF
--- a/command/repo/add.go
+++ b/command/repo/add.go
@@ -43,7 +43,6 @@ var CommandAdd = &cli.Command{
 			Name:    "branch",
 			Aliases: []string{"b"},
 			Usage:   "default branch for the repository",
-			Value:   "main",
 		},
 		&cli.StringFlag{
 			EnvVars: []string{"VELA_LINK", "REPO_LINK"},

--- a/command/repo/update.go
+++ b/command/repo/update.go
@@ -43,7 +43,6 @@ var CommandUpdate = &cli.Command{
 			Name:    "branch",
 			Aliases: []string{"b"},
 			Usage:   "default branch for the repository",
-			Value:   "main",
 		},
 		&cli.StringFlag{
 			EnvVars: []string{"VELA_LINK", "REPO_LINK"},


### PR DESCRIPTION
We gather this data in the server [here](https://github.com/go-vela/server/blob/8a24f966f4c59b712df6f108b3b55d28a3923f92/scm/github/repo.go#L479) for adding repos, and we have the database value for updating (should not updated unless specified in command).