### PR TITLE
enhance(pipeline/exec): incorporate privileged image handling in runtime config

### DIFF
--- a/action/pipeline/exec.go
+++ b/action/pipeline/exec.go
@@ -97,8 +97,9 @@ func (c *Config) Exec(client compiler.Engine) error {
 	//
 	// https://pkg.go.dev/github.com/go-vela/worker/runtime?tab=doc#New
 	_runtime, err := runtime.New(&runtime.Setup{
-		Driver:      constants.DriverDocker,
-		HostVolumes: c.Volumes,
+		Driver:           constants.DriverDocker,
+		HostVolumes:      c.Volumes,
+		PrivilegedImages: c.PrivilegedImages,
 	})
 	if err != nil {
 		return err

--- a/action/pipeline/pipeline.go
+++ b/action/pipeline/pipeline.go
@@ -5,27 +5,28 @@ package pipeline
 // Config represents the configuration necessary
 // to perform pipeline related requests with Vela.
 type Config struct {
-	Action        string
-	Branch        string
-	Comment       string
-	Event         string
-	Tag           string
-	Target        string
-	Org           string
-	Repo          string
-	Ref           string
-	File          string
-	FileChangeset []string
-	Path          string
-	Type          string
-	Stages        bool
-	Template      bool
-	TemplateFiles []string
-	Local         bool
-	Remote        bool
-	Volumes       []string
-	Page          int
-	PerPage       int
-	Output        string
-	PipelineType  string
+	Action           string
+	Branch           string
+	Comment          string
+	Event            string
+	Tag              string
+	Target           string
+	Org              string
+	Repo             string
+	Ref              string
+	File             string
+	FileChangeset    []string
+	Path             string
+	Type             string
+	Stages           bool
+	Template         bool
+	TemplateFiles    []string
+	Local            bool
+	Remote           bool
+	Volumes          []string
+	PrivilegedImages []string
+	Page             int
+	PerPage          int
+	Output           string
+	PipelineType     string
 }

--- a/command/pipeline/exec.go
+++ b/command/pipeline/exec.go
@@ -97,11 +97,20 @@ var CommandExec = &cli.Command{
 			Aliases: []string{"p"},
 			Usage:   "provide the path to the file for the pipeline",
 		},
+
+		// Runtime Flags
+
 		&cli.StringSliceFlag{
 			EnvVars: []string{"VELA_VOLUMES", "PIPELINE_VOLUMES"},
 			Name:    "volume",
 			Aliases: []string{"v"},
 			Usage:   "provide list of local volumes to mount",
+		},
+		&cli.StringSliceFlag{
+			EnvVars: []string{"VELA_PRIVILEGED_IMAGES", "PIPELINE_PRIVILEGED_IMAGES"},
+			Name:    "privileged-images",
+			Aliases: []string{"pi"},
+			Usage:   "provide list of pipeline images that will run in privileged mode",
 		},
 
 		// Repo Flags
@@ -256,21 +265,22 @@ func exec(c *cli.Context) error {
 	//
 	// https://pkg.go.dev/github.com/go-vela/cli/action/pipeline?tab=doc#Config
 	p := &pipeline.Config{
-		Action:        internal.ActionExec,
-		Branch:        c.String("branch"),
-		Comment:       c.String("comment"),
-		Event:         c.String("event"),
-		Tag:           c.String("tag"),
-		Target:        c.String("target"),
-		Org:           c.String(internal.FlagOrg),
-		Repo:          c.String(internal.FlagRepo),
-		File:          c.String("file"),
-		FileChangeset: c.StringSlice("file-changeset"),
-		TemplateFiles: c.StringSlice("template-file"),
-		Local:         c.Bool("local"),
-		Path:          c.String("path"),
-		Volumes:       c.StringSlice("volume"),
-		PipelineType:  c.String("pipeline-type"),
+		Action:           internal.ActionExec,
+		Branch:           c.String("branch"),
+		Comment:          c.String("comment"),
+		Event:            c.String("event"),
+		Tag:              c.String("tag"),
+		Target:           c.String("target"),
+		Org:              c.String(internal.FlagOrg),
+		Repo:             c.String(internal.FlagRepo),
+		File:             c.String("file"),
+		FileChangeset:    c.StringSlice("file-changeset"),
+		TemplateFiles:    c.StringSlice("template-file"),
+		Local:            c.Bool("local"),
+		Path:             c.String("path"),
+		Volumes:          c.StringSlice("volume"),
+		PrivilegedImages: c.StringSlice("privileged-images"),
+		PipelineType:     c.String("pipeline-type"),
 	}
 
 	// validate pipeline configuration


### PR DESCRIPTION
Figured it may be helpful for users who need certain images ran in privileged mode during a Vela build.