### PR TITLE
fix(pipeline): include starlark exec limit to compiler flags in exec + validate

### DIFF
--- a/command/pipeline/exec.go
+++ b/command/pipeline/exec.go
@@ -161,6 +161,13 @@ var CommandExec = &cli.Command{
 			Usage:   "set the maximum depth for nested templates",
 			Value:   3,
 		},
+		&cli.Uint64Flag{
+			EnvVars: []string{"VELA_COMPILER_STARLARK_EXEC_LIMIT", "COMPILER_STARLARK_EXEC_LIMIT"},
+			Name:    "compiler-starlark-exec-limit",
+			Aliases: []string{"starlark-exec-limit", "sel"},
+			Usage:   "set the starlark execution step limit for compiling starlark pipelines",
+			Value:   7500,
+		},
 
 		// Environment Flags
 		&cli.BoolFlag{
@@ -298,6 +305,9 @@ func exec(c *cli.Context) error {
 	if err != nil {
 		return err
 	}
+
+	// set starlark exec limit
+	client.StarlarkExecLimit = c.Uint64("compiler-starlark-exec-limit")
 
 	// set when user is sourcing templates from local machine
 	if len(p.TemplateFiles) != 0 {

--- a/command/pipeline/validate.go
+++ b/command/pipeline/validate.go
@@ -86,6 +86,13 @@ var CommandValidate = &cli.Command{
 			Usage:   "set the maximum depth for nested templates",
 			Value:   3,
 		},
+		&cli.Uint64Flag{
+			EnvVars: []string{"VELA_COMPILER_STARLARK_EXEC_LIMIT", "COMPILER_STARLARK_EXEC_LIMIT"},
+			Name:    "compiler-starlark-exec-limit",
+			Aliases: []string{"starlark-exec-limit", "sel"},
+			Usage:   "set the starlark execution step limit for compiling starlark pipelines",
+			Value:   7500,
+		},
 		&cli.BoolFlag{
 			EnvVars: []string{"VELA_REMOTE", "PIPELINE_REMOTE"},
 			Name:    "remote",
@@ -190,6 +197,9 @@ func validate(c *cli.Context) error {
 	if err != nil {
 		return err
 	}
+
+	// set starlark exec limit
+	client.StarlarkExecLimit = c.Uint64("compiler-starlark-exec-limit")
 
 	// set when user is sourcing templates from local machine
 	if len(p.TemplateFiles) != 0 {

--- a/command/pipeline/validate_test.go
+++ b/command/pipeline/validate_test.go
@@ -30,6 +30,7 @@ func TestPipeline_Validate(t *testing.T) {
 	fullSet.String("repo", "octocat", "doc")
 	fullSet.String("output", "json", "doc")
 	fullSet.String("pipeline-type", "yaml", "doc")
+	fullSet.Uint64("compiler-starlark-exec-limit", 10000, "doc")
 	fullSet.Bool("remote", true, "doc")
 
 	// setup flags


### PR DESCRIPTION
More parity with our actual compiler