### PR TITLE
chore(version): Remove invalid flag from help text

### DIFF
--- a/command/version/version.go
+++ b/command/version/version.go
@@ -33,7 +33,7 @@ var CommandVersion = &cli.Command{
 	CustomHelpTemplate: fmt.Sprintf(`%s
 EXAMPLES:
   1. Output Vela version information
-    $ {{.HelpName}} --api.addr https://vela.example.com
+    $ {{.HelpName}}
   2. Output Vela version information with JSON output
     $ {{.HelpName}} --output json
 


### PR DESCRIPTION
This flag is not supported in the `version` command (though it would be nice to supply a Vela server and retrieve the version of the server).