### PR TITLE
fix(pipeline): validate presence of tag on tag events to avoid panic

### DIFF
--- a/action/pipeline/validate.go
+++ b/action/pipeline/validate.go
@@ -38,10 +38,6 @@ func (c *Config) Validate() error {
 		fallthrough
 	case "expand":
 		fallthrough
-	case "exec":
-		if strings.EqualFold(c.Event, constants.EventTag) && len(c.Tag) == 0 {
-			return fmt.Errorf("no tag provided for tag event")
-		}
 	case "view":
 		// check if pipeline org is set
 		if len(c.Org) == 0 {
@@ -73,6 +69,10 @@ func (c *Config) Validate() error {
 			if len(parts) != 2 {
 				return fmt.Errorf("invalid format for template file: %s (valid format: <name>:<source>)", file)
 			}
+		}
+	case "exec":
+		if strings.EqualFold(c.Event, constants.EventTag) && len(c.Tag) == 0 {
+			return fmt.Errorf("no tag provided for tag event")
 		}
 	}
 

--- a/action/pipeline/validate.go
+++ b/action/pipeline/validate.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/go-vela/cli/internal/output"
 	"github.com/go-vela/sdk-go/vela"
+	"github.com/go-vela/types/constants"
 	"github.com/go-vela/types/library"
 
 	"github.com/go-vela/server/compiler"
@@ -37,6 +38,10 @@ func (c *Config) Validate() error {
 		fallthrough
 	case "expand":
 		fallthrough
+	case "exec":
+		if strings.EqualFold(c.Event, constants.EventTag) && len(c.Tag) == 0 {
+			return fmt.Errorf("no tag provided for tag event")
+		}
 	case "view":
 		// check if pipeline org is set
 		if len(c.Org) == 0 {

--- a/action/pipeline/validate_test.go
+++ b/action/pipeline/validate_test.go
@@ -33,6 +33,25 @@ func TestPipeline_Config_Validate(t *testing.T) {
 			},
 		},
 		{
+			failure: true,
+			config: &Config{
+				Action: "exec",
+				Org:    "github",
+				Repo:   "octocat",
+				Event:  "tag",
+			},
+		},
+		{
+			failure: false,
+			config: &Config{
+				Action: "exec",
+				Org:    "github",
+				Repo:   "octocat",
+				Event:  "tag",
+				Tag:    "v1.0.0",
+			},
+		},
+		{
 			failure: false,
 			config: &Config{
 				Action: "expand",


### PR DESCRIPTION
Due to how the environment is set up, the exec pipeline command needs to have a tag value on a tag event.

```sh
$ vela exec pipeline --pipeline-type go --event tag
panic: runtime error: index out of range [1] with length 1

goroutine 1 [running]:
github.com/go-vela/types/library.(*Build).Environment(0xc0006d7560, {0x2cc080e, 0x9}, {0x2cb70f5, 0x4})
	/Users/Z004X4Y/go/pkg/mod/github.com/go-vela/types@v0.23.0-rc2/library/build.go:198 +0x31dd
github.com/go-vela/server/compiler/native.environment(0xc000606968?, 0x0, 0xc0002b81a0, 0x0)
	/Users/Z004X4Y/go/pkg/mod/github.com/go-vela/server@v0.23.0-rc2/compiler/native/environment.go:326 +0xaec
github.com/go-vela/server/compiler/native.(*client).EnvironmentBuild(0xc0002204b0)
.....
```

Changed to:

```sh
$ vela exec pipeline --pipeline-type go --event tag 
FATA[0000] no tag provided for tag event  
```