### PR TITLE
fix(pipeline): always set local to true for validate local

### DIFF
--- a/command/pipeline/validate.go
+++ b/command/pipeline/validate.go
@@ -203,7 +203,6 @@ func validate(c *cli.Context) error {
 
 	// set when user is sourcing templates from local machine
 	if len(p.TemplateFiles) != 0 {
-		client.WithLocal(true)
 		client.WithLocalTemplates(p.TemplateFiles)
 		client.TemplateDepth = c.Int("max-template-depth")
 	} else {
@@ -216,5 +215,5 @@ func validate(c *cli.Context) error {
 	// execute the validate local call for the pipeline configuration
 	//
 	// https://pkg.go.dev/github.com/go-vela/cli/action/pipeline?tab=doc#Config.ValidateLocal
-	return p.ValidateLocal(client.WithPrivateGitHub(c.String(internal.FlagCompilerGitHubURL), c.String(internal.FlagCompilerGitHubToken)))
+	return p.ValidateLocal(client.WithLocal(true).WithPrivateGitHub(c.String(internal.FlagCompilerGitHubURL), c.String(internal.FlagCompilerGitHubToken)))
 }


### PR DESCRIPTION
We've got the necessary logic packed in to the compiler code [here](https://github.com/go-vela/server/blob/16ef8aca2af613a41e517d77c11e03b915836fda/compiler/native/expand.go#L209-L247) to have `ValidateLocal` always use a compiler engine with `local` set to `true`.

- If the template is of type `file` and the engine is `local`, then it will fetch from the filesystem. 
- If the template is of type `github` and the engine is `local`, it will fallthrough and attempt to fetch using user provided credentials
- If the template is being replaced using `--template-file` it will source those from the filesystem like usual.

Closes https://github.com/go-vela/community/issues/916