### PR TITLE
fix(pipeline): remove check for if template replacement was used

### DIFF
--- a/action/pipeline/validate.go
+++ b/action/pipeline/validate.go
@@ -115,22 +115,6 @@ func (c *Config) ValidateLocal(client compiler.Engine) error {
 		return err
 	}
 
-	// check to see if locally provided templates were included in compilation
-	for _, tmpl := range c.TemplateFiles {
-		parts := strings.Split(tmpl, ":")
-		included := false
-
-		for _, pTmpl := range p.Templates {
-			if strings.EqualFold(parts[0], pTmpl.Name) {
-				included = true
-			}
-		}
-
-		if !included {
-			return fmt.Errorf("local template with name %s not included in pipeline templates", parts[0])
-		}
-	}
-
 	// output the message in stderr format
 	//
 	// https://pkg.go.dev/github.com/go-vela/cli/internal/output?tab=doc#Stderr


### PR DESCRIPTION
This actually stops nested templates from working if you try to replace a nested template because CompileLite doesn't return those nested templates. I think it's reasonable to expect it to be replaced.