### PR TITLE
fix(secrets): abstract populateEvents for secret usage

### DIFF
--- a/action/repo/add.go
+++ b/action/repo/add.go
@@ -6,13 +6,12 @@ package repo
 import (
 	"fmt"
 
+	"github.com/go-vela/cli/internal"
 	"github.com/go-vela/cli/internal/output"
 
 	"github.com/go-vela/sdk-go/vela"
 
-	"github.com/go-vela/types/constants"
 	"github.com/go-vela/types/library"
-	"github.com/go-vela/types/library/actions"
 
 	"github.com/sirupsen/logrus"
 )
@@ -45,7 +44,7 @@ func (c *Config) Add(client *vela.Client) error {
 	logrus.Tracef("adding repo %s/%s", c.Org, c.Name)
 
 	if len(c.Events) > 0 {
-		populateEvents(r, c.Events)
+		r.SetAllowEvents(internal.PopulateEvents(c.Events))
 	}
 
 	// send API call to add a repository
@@ -84,71 +83,4 @@ func (c *Config) Add(client *vela.Client) error {
 		// https://pkg.go.dev/github.com/go-vela/cli/internal/output?tab=doc#Stdout
 		return output.Stdout(repo)
 	}
-}
-
-// populateEvents is a helper function designed to fill both the legacy `Allow<_>` fields
-// as well as the `AllowEvents` struct with the correct values based on a slice input.
-func populateEvents(r *library.Repo, events []string) {
-	result := new(library.Events)
-	push := new(actions.Push)
-	pull := new(actions.Pull)
-	comment := new(actions.Comment)
-	deploy := new(actions.Deploy)
-
-	// -- legacy allow events init --
-	r.SetAllowPush(false)
-	r.SetAllowPull(false)
-	r.SetAllowTag(false)
-	r.SetAllowDeploy(false)
-	r.SetAllowComment(false)
-
-	// iterate through all events provided
-	for _, event := range events {
-		switch event {
-		case constants.EventPush, constants.EventPush + ":branch":
-			r.SetAllowPush(true)
-			push.SetBranch(true)
-		case constants.EventTag, constants.EventPush + ":" + constants.EventTag:
-			r.SetAllowTag(true)
-			push.SetTag(true)
-		case constants.EventPull, AlternatePull:
-			r.SetAllowPull(true)
-			pull.SetOpened(true)
-			pull.SetReopened(true)
-			pull.SetSynchronize(true)
-		case constants.EventDeploy, AlternateDeploy, constants.EventDeploy + ":" + constants.ActionCreated:
-			r.SetAllowDeploy(true)
-			deploy.SetCreated(true)
-		case constants.EventComment:
-			r.SetAllowComment(true)
-			comment.SetCreated(true)
-			comment.SetEdited(true)
-		case constants.EventDelete:
-			push.SetDeleteBranch(true)
-			push.SetDeleteTag(true)
-		case constants.EventPull + ":" + constants.ActionOpened:
-			pull.SetOpened(true)
-		case constants.EventPull + ":" + constants.ActionEdited:
-			pull.SetEdited(true)
-		case constants.EventPull + ":" + constants.ActionSynchronize:
-			pull.SetSynchronize(true)
-		case constants.EventPull + ":" + constants.ActionReopened:
-			pull.SetReopened(true)
-		case constants.EventComment + ":" + constants.ActionCreated:
-			comment.SetCreated(true)
-		case constants.EventComment + ":" + constants.ActionEdited:
-			comment.SetEdited(true)
-		case constants.EventDelete + ":" + constants.ActionBranch:
-			push.SetDeleteBranch(true)
-		case constants.EventDelete + ":" + constants.ActionTag:
-			push.SetDeleteTag(true)
-		}
-	}
-
-	result.SetPush(push)
-	result.SetPullRequest(pull)
-	result.SetDeployment(deploy)
-	result.SetComment(comment)
-
-	r.SetAllowEvents(result)
 }

--- a/action/repo/add_test.go
+++ b/action/repo/add_test.go
@@ -7,9 +7,6 @@ import (
 	"testing"
 
 	"github.com/go-vela/server/mock/server"
-	"github.com/go-vela/types/library"
-	"github.com/go-vela/types/library/actions"
-	"github.com/google/go-cmp/cmp"
 
 	"github.com/go-vela/sdk-go/vela"
 )
@@ -152,90 +149,6 @@ func TestRepo_Config_Add(t *testing.T) {
 
 		if err != nil {
 			t.Errorf("Add returned err: %v", err)
-		}
-	}
-}
-
-func TestRepo_populateEvents(t *testing.T) {
-	// setup types
-	tBool := true
-	fBool := false
-
-	// setup tests
-	tests := []struct {
-		name   string
-		events []string
-		want   *library.Repo
-	}{
-		{
-			name:   "happy path legacy events",
-			events: []string{"push", "pull_request", "tag", "deploy", "comment", "delete"},
-			want: &library.Repo{
-				AllowPush:    &tBool,
-				AllowPull:    &tBool,
-				AllowTag:     &tBool,
-				AllowDeploy:  &tBool,
-				AllowComment: &tBool,
-				AllowEvents: &library.Events{
-					Push: &actions.Push{
-						Branch:       &tBool,
-						Tag:          &tBool,
-						DeleteBranch: &tBool,
-						DeleteTag:    &tBool,
-					},
-					PullRequest: &actions.Pull{
-						Opened:      &tBool,
-						Reopened:    &tBool,
-						Synchronize: &tBool,
-					},
-					Deployment: &actions.Deploy{
-						Created: &tBool,
-					},
-					Comment: &actions.Comment{
-						Created: &tBool,
-						Edited:  &tBool,
-					},
-				},
-			},
-		},
-		{
-			name:   "action specific",
-			events: []string{"push:branch", "push:tag", "pull_request:opened", "pull_request:edited", "deployment:created", "comment:created", "delete:branch", "delete:tag"},
-			want: &library.Repo{
-				AllowPush:    &tBool,
-				AllowPull:    &fBool,
-				AllowTag:     &tBool,
-				AllowDeploy:  &tBool,
-				AllowComment: &fBool,
-				AllowEvents: &library.Events{
-					Push: &actions.Push{
-						Branch:       &tBool,
-						Tag:          &tBool,
-						DeleteBranch: &tBool,
-						DeleteTag:    &tBool,
-					},
-					PullRequest: &actions.Pull{
-						Opened: &tBool,
-						Edited: &tBool,
-					},
-					Deployment: &actions.Deploy{
-						Created: &tBool,
-					},
-					Comment: &actions.Comment{
-						Created: &tBool,
-					},
-				},
-			},
-		},
-	}
-
-	// run tests
-	for _, test := range tests {
-		repo := new(library.Repo)
-		populateEvents(repo, test.events)
-
-		if diff := cmp.Diff(test.want, repo); diff != "" {
-			t.Errorf("populateEvents failed for %s mismatch (-want +got):\n%s", test.name, diff)
 		}
 	}
 }

--- a/action/repo/repo.go
+++ b/action/repo/repo.go
@@ -25,9 +25,3 @@ type Config struct {
 	PerPage      int
 	Output       string
 }
-
-// Alternate constants for webhook events.
-const (
-	AlternateDeploy = "deploy"
-	AlternatePull   = "pull"
-)

--- a/action/repo/update.go
+++ b/action/repo/update.go
@@ -6,6 +6,7 @@ package repo
 import (
 	"fmt"
 
+	"github.com/go-vela/cli/internal"
 	"github.com/go-vela/cli/internal/output"
 
 	"github.com/go-vela/sdk-go/vela"
@@ -41,7 +42,7 @@ func (c *Config) Update(client *vela.Client) error {
 	}
 
 	if len(c.Events) > 0 {
-		populateEvents(r, c.Events)
+		r.SetAllowEvents(internal.PopulateEvents(c.Events))
 	}
 
 	logrus.Tracef("updating repo %s/%s", c.Org, c.Name)

--- a/action/secret/add.go
+++ b/action/secret/add.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/go-vela/cli/internal"
 	"github.com/go-vela/cli/internal/output"
 
 	"github.com/go-vela/sdk-go/vela"
@@ -60,6 +61,11 @@ func (c *Config) Add(client *vela.Client) error {
 		Events:            &c.Events,
 		AllowCommand:      c.AllowCommand,
 		AllowSubstitution: c.AllowSubstitution,
+	}
+
+	// populate events if provided
+	if len(c.Events) > 0 {
+		s.SetAllowEvents(internal.PopulateEvents(c.Events))
 	}
 
 	logrus.Tracef("adding secret %s/%s/%s/%s/%s", c.Engine, c.Type, c.Org, name, c.Name)

--- a/action/secret/update.go
+++ b/action/secret/update.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/go-vela/cli/internal"
 	"github.com/go-vela/cli/internal/output"
 
 	"github.com/go-vela/sdk-go/vela"
@@ -60,6 +61,11 @@ func (c *Config) Update(client *vela.Client) error {
 		Events:            &c.Events,
 		AllowCommand:      c.AllowCommand,
 		AllowSubstitution: c.AllowSubstitution,
+	}
+
+	// populate events if provided
+	if len(c.Events) > 0 {
+		s.SetAllowEvents(internal.PopulateEvents(c.Events))
 	}
 
 	logrus.Tracef("modifying secret %s/%s/%s/%s/%s", c.Engine, c.Type, c.Org, name, c.Name)

--- a/command/repo/add.go
+++ b/command/repo/add.go
@@ -106,7 +106,7 @@ var CommandAdd = &cli.Command{
 		&cli.StringSliceFlag{
 			EnvVars: []string{"VELA_EVENTS", "REPO_EVENTS", "VELA_ADD_EVENTS", "REPO_ADD_EVENTS"},
 			Name:    "event",
-			Aliases: []string{"events", "add-event", "add-events", "e"},
+			Aliases: []string{"events", "e"},
 			Usage:   "webhook event(s) repository responds to",
 		},
 		&cli.StringFlag{

--- a/command/repo/update.go
+++ b/command/repo/update.go
@@ -106,7 +106,7 @@ var CommandUpdate = &cli.Command{
 		&cli.StringSliceFlag{
 			EnvVars: []string{"VELA_EVENTS", "REPO_EVENTS", "VELA_ADD_EVENTS", "REPO_ADD_EVENTS"},
 			Name:    "event",
-			Aliases: []string{"events", "add-event", "add-events", "e"},
+			Aliases: []string{"events", "e"},
 			Usage:   "webhook event(s) repository responds to",
 		},
 		&cli.StringFlag{

--- a/command/secret/add.go
+++ b/command/secret/add.go
@@ -82,13 +82,8 @@ var CommandAdd = &cli.Command{
 		&cli.StringSliceFlag{
 			EnvVars: []string{"VELA_EVENTS", "SECRET_EVENTS"},
 			Name:    "event",
-			Aliases: []string{"ev"},
+			Aliases: []string{"events", "ev"},
 			Usage:   "provide the event(s) that can access this secret",
-			Value: cli.NewStringSlice(
-				constants.EventDeploy,
-				constants.EventPush,
-				constants.EventTag,
-			),
 		},
 		&cli.StringFlag{
 			EnvVars: []string{"VELA_COMMAND", "SECRET_COMMAND"},

--- a/command/secret/update.go
+++ b/command/secret/update.go
@@ -82,7 +82,7 @@ var CommandUpdate = &cli.Command{
 		&cli.StringSliceFlag{
 			EnvVars: []string{"VELA_EVENTS", "SECRET_EVENTS"},
 			Name:    "event",
-			Aliases: []string{"ev"},
+			Aliases: []string{"events", "ev"},
 			Usage:   "provide the event(s) that can access this secret",
 		},
 		&cli.StringFlag{

--- a/internal/events.go
+++ b/internal/events.go
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package internal
+
+import (
+	"github.com/go-vela/types/constants"
+	"github.com/go-vela/types/library"
+	"github.com/go-vela/types/library/actions"
+)
+
+const (
+	// AlternatePull is an alternate name for the pull_request event.
+	AlternatePull = "pull"
+	// AlternateDeploy is an alternate name for the deployment event.
+	AlternateDeploy = "deploy"
+)
+
+// PopulateEvents is a helper function designed to fill both the legacy `Allow<_>` fields
+// as well as the `AllowEvents` struct with the correct values based on a slice input.
+func PopulateEvents(events []string) *library.Events {
+	result := new(library.Events)
+	push := new(actions.Push)
+	pull := new(actions.Pull)
+	comment := new(actions.Comment)
+	deploy := new(actions.Deploy)
+	schedule := new(actions.Schedule)
+
+	// iterate through all events provided
+	for _, event := range events {
+		switch event {
+		// push actions
+		case constants.EventPush, constants.EventPush + ":branch":
+			push.SetBranch(true)
+		case constants.EventTag, constants.EventPush + ":" + constants.EventTag:
+			push.SetTag(true)
+		case constants.EventDelete + ":" + constants.ActionBranch:
+			push.SetDeleteBranch(true)
+		case constants.EventDelete + ":" + constants.ActionTag:
+			push.SetDeleteTag(true)
+		case constants.EventDelete:
+			push.SetDeleteBranch(true)
+			push.SetDeleteTag(true)
+
+		// pull_request actions
+		case constants.EventPull, AlternatePull:
+			pull.SetOpened(true)
+			pull.SetReopened(true)
+			pull.SetSynchronize(true)
+		case constants.EventPull + ":" + constants.ActionOpened:
+			pull.SetOpened(true)
+		case constants.EventPull + ":" + constants.ActionEdited:
+			pull.SetEdited(true)
+		case constants.EventPull + ":" + constants.ActionSynchronize:
+			pull.SetSynchronize(true)
+		case constants.EventPull + ":" + constants.ActionReopened:
+			pull.SetReopened(true)
+
+		// deployment actions
+		case constants.EventDeploy, AlternateDeploy, constants.EventDeploy + ":" + constants.ActionCreated:
+			deploy.SetCreated(true)
+
+		// comment actions
+		case constants.EventComment:
+			comment.SetCreated(true)
+			comment.SetEdited(true)
+		case constants.EventComment + ":" + constants.ActionCreated:
+			comment.SetCreated(true)
+		case constants.EventComment + ":" + constants.ActionEdited:
+			comment.SetEdited(true)
+
+		// schedule actions
+		case constants.EventSchedule, constants.EventSchedule + ":run":
+			schedule.SetRun(true)
+		}
+	}
+
+	result.SetPush(push)
+	result.SetPullRequest(pull)
+	result.SetDeployment(deploy)
+	result.SetComment(comment)
+	result.SetSchedule(schedule)
+
+	return result
+}

--- a/internal/events_test.go
+++ b/internal/events_test.go
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package internal
+
+import (
+	"testing"
+
+	"github.com/go-vela/types/library"
+	"github.com/go-vela/types/library/actions"
+	"github.com/google/go-cmp/cmp"
+)
+
+func Test_PopulateEvents(t *testing.T) {
+	// setup types
+	tBool := true
+
+	// setup tests
+	tests := []struct {
+		name   string
+		events []string
+		want   *library.Events
+	}{
+		{
+			name:   "general events",
+			events: []string{"push", "pull_request", "tag", "deploy", "comment", "delete", "schedule"},
+			want: &library.Events{
+				Push: &actions.Push{
+					Branch:       &tBool,
+					Tag:          &tBool,
+					DeleteBranch: &tBool,
+					DeleteTag:    &tBool,
+				},
+				PullRequest: &actions.Pull{
+					Opened:      &tBool,
+					Reopened:    &tBool,
+					Synchronize: &tBool,
+				},
+				Deployment: &actions.Deploy{
+					Created: &tBool,
+				},
+				Comment: &actions.Comment{
+					Created: &tBool,
+					Edited:  &tBool,
+				},
+				Schedule: &actions.Schedule{
+					Run: &tBool,
+				},
+			},
+		},
+		{
+			name:   "action specific events",
+			events: []string{"push:branch", "push:tag", "pull_request:opened", "pull_request:edited", "deployment:created", "comment:created", "delete:branch", "delete:tag", "schedule:run"},
+			want: &library.Events{
+				Push: &actions.Push{
+					Branch:       &tBool,
+					Tag:          &tBool,
+					DeleteBranch: &tBool,
+					DeleteTag:    &tBool,
+				},
+				PullRequest: &actions.Pull{
+					Opened: &tBool,
+					Edited: &tBool,
+				},
+				Deployment: &actions.Deploy{
+					Created: &tBool,
+				},
+				Comment: &actions.Comment{
+					Created: &tBool,
+				},
+				Schedule: &actions.Schedule{
+					Run: &tBool,
+				},
+			},
+		},
+	}
+
+	// run tests
+	for _, test := range tests {
+		got := PopulateEvents(test.events)
+
+		if diff := cmp.Diff(test.want, got); diff != "" {
+			t.Errorf("PopulateEvents failed for %s mismatch (-want +got):\n%s", test.name, diff)
+		}
+	}
+}


### PR DESCRIPTION
`add` and `update` secrets were missing the new `AllowEvents` functionality. This PR addresses that.