### PR TITLE
feat(local exec): add ability to skip steps

### DIFF
--- a/action/pipeline/exec.go
+++ b/action/pipeline/exec.go
@@ -131,7 +131,6 @@ func (c *Config) Exec(client compiler.Engine) error {
 
 		// counter for total steps to run
 		totalSteps := 0
-
 		for i, stage := range _pipeline.Stages {
 
 			filteredStageSteps := stage.Steps[:0]
@@ -151,10 +150,8 @@ func (c *Config) Exec(client compiler.Engine) error {
 		if totalSteps <= 1 {
 			return fmt.Errorf("no steps left to run after removing skipped steps")
 		}
-
 	} else {
 		// if not using stages
-
 		filteredSteps := _pipeline.Steps[:0]
 
 		for _, step := range _pipeline.Steps {
@@ -162,6 +159,7 @@ func (c *Config) Exec(client compiler.Engine) error {
 				filteredSteps = append(filteredSteps, step)
 			}
 		}
+
 		_pipeline.Steps = filteredSteps
 
 		// check if any steps are left to run, excluding "init" step

--- a/action/pipeline/exec.go
+++ b/action/pipeline/exec.go
@@ -119,16 +119,15 @@ func (c *Config) Exec(client compiler.Engine) error {
 	// create a slice for steps to be removed
 	stepsToRemove := c.SkipSteps
 
-	// print steps to be removed to the user
+	// print and remove steps
 	if len(stepsToRemove) > 0 {
 		for _, stepName := range stepsToRemove {
 			fmt.Println("skip step: ", stepName)
 		}
-	}
 
-	// call the skipSteps function
-	if err := skipSteps(_pipeline, stepsToRemove); err != nil {
-		return err
+		if err := skipSteps(_pipeline, stepsToRemove); err != nil {
+			return err
+		}
 	}
 
 	// create current directory path for local mount

--- a/action/pipeline/exec.go
+++ b/action/pipeline/exec.go
@@ -17,6 +17,7 @@ import (
 	"github.com/go-vela/cli/version"
 	api "github.com/go-vela/server/api/types"
 	"github.com/go-vela/server/compiler"
+	"github.com/go-vela/server/compiler/types/pipeline"
 	"github.com/go-vela/server/constants"
 	"github.com/go-vela/worker/executor"
 	"github.com/go-vela/worker/runtime"
@@ -118,52 +119,16 @@ func (c *Config) Exec(client compiler.Engine) error {
 	// create a slice for steps to be removed
 	stepsToRemove := c.SkipSteps
 
-	// filter out steps to be removed
-	if len(_pipeline.Stages) > 0 {
-		// counter for total steps to run
-		totalSteps := 0
-
-		for i, stage := range _pipeline.Stages {
-			filteredStageSteps := stage.Steps[:0]
-
-			for _, step := range stage.Steps {
-				// if c.steps contains step.Name
-				if !slices.Contains(stepsToRemove, step.Name) {
-					filteredStageSteps = append(filteredStageSteps, step)
-					totalSteps++
-				}
-
-				_pipeline.Stages[i].Steps = filteredStageSteps
-			}
+	// print steps to be removed to the user
+	if len(stepsToRemove) > 0 {
+		for _, stepName := range stepsToRemove {
+			fmt.Println("skip step: ", stepName)
 		}
+	}
 
-		// check if any steps are left to run, excluding "init" step
-		if totalSteps <= 1 {
-			return fmt.Errorf("no steps left to run after removing skipped steps")
-		}
-	} else {
-		// if not using stages
-		filteredSteps := _pipeline.Steps[:0]
-
-		for _, step := range _pipeline.Steps {
-			if !slices.Contains(stepsToRemove, step.Name) {
-				filteredSteps = append(filteredSteps, step)
-			}
-		}
-
-		// print steps to be removed to the user
-		if len(stepsToRemove) > 0 {
-			for _, stepName := range stepsToRemove {
-				fmt.Println("skip step: ", stepName)
-			}
-		}
-
-		_pipeline.Steps = filteredSteps
-
-		// check if any steps are left to run, excluding "init" step
-		if len(_pipeline.Steps) <= 1 {
-			return fmt.Errorf("no steps left to run after removing skipped steps")
-		}
+	// call the skipSteps function
+	if err := skipSteps(_pipeline, stepsToRemove); err != nil {
+		return err
 	}
 
 	// create current directory path for local mount
@@ -262,6 +227,51 @@ func (c *Config) Exec(client compiler.Engine) error {
 	err = _executor.ExecBuild(ctx)
 	if err != nil {
 		return fmt.Errorf("unable to execute build: %w", err)
+	}
+
+	return nil
+}
+
+// skipSteps filters out steps to be removed from the pipeline.
+func skipSteps(_pipeline *pipeline.Build, stepsToRemove []string) error {
+	// filter out steps to be removed
+	if len(_pipeline.Stages) > 0 {
+		// counter for total steps to run
+		totalSteps := 0
+
+		for i, stage := range _pipeline.Stages {
+			filteredStageSteps := stage.Steps[:0]
+
+			for _, step := range stage.Steps {
+				if !slices.Contains(stepsToRemove, step.Name) {
+					filteredStageSteps = append(filteredStageSteps, step)
+					totalSteps++
+				}
+			}
+
+			_pipeline.Stages[i].Steps = filteredStageSteps
+		}
+
+		// check if any steps are left to run, excluding "init" step
+		if totalSteps <= 1 {
+			return fmt.Errorf("no steps left to run after removing skipped steps")
+		}
+	} else {
+		// if not using stages
+		filteredSteps := _pipeline.Steps[:0]
+
+		for _, step := range _pipeline.Steps {
+			if !slices.Contains(stepsToRemove, step.Name) {
+				filteredSteps = append(filteredSteps, step)
+			}
+		}
+
+		_pipeline.Steps = filteredSteps
+
+		// check if any steps are left to run, excluding "init" step
+		if len(_pipeline.Steps) <= 1 {
+			return fmt.Errorf("no steps left to run after removing skipped steps")
+		}
 	}
 
 	return nil

--- a/action/pipeline/exec.go
+++ b/action/pipeline/exec.go
@@ -122,7 +122,7 @@ func (c *Config) Exec(client compiler.Engine) error {
 	// print and remove steps
 	if len(stepsToRemove) > 0 {
 		for _, stepName := range stepsToRemove {
-			fmt.Println("skip step: ", stepName)
+			logrus.Info("skipping step: ", stepName)
 		}
 
 		if err := skipSteps(_pipeline, stepsToRemove); err != nil {

--- a/action/pipeline/exec.go
+++ b/action/pipeline/exec.go
@@ -116,7 +116,7 @@ func (c *Config) Exec(client compiler.Engine) error {
 	}
 
 	// create a slice for steps to be removed
-	stepsToRemove := c.Steps
+	stepsToRemove := c.SkipSteps
 
 	// print steps to be removed to the user
 	if len(stepsToRemove) > 0 {
@@ -137,6 +137,8 @@ func (c *Config) Exec(client compiler.Engine) error {
 			for _, step := range stage.Steps {
 				// if c.steps contains step.Name
 				if !slices.Contains(stepsToRemove, step.Name) {
+					fmt.Println("skip step: ", stepsToRemove)
+
 					filteredStageSteps = append(filteredStageSteps, step)
 					totalSteps++
 				}
@@ -155,6 +157,8 @@ func (c *Config) Exec(client compiler.Engine) error {
 
 		for _, step := range _pipeline.Steps {
 			if !slices.Contains(stepsToRemove, step.Name) {
+				fmt.Println("skip step: ", stepsToRemove)
+
 				filteredSteps = append(filteredSteps, step)
 			}
 		}

--- a/action/pipeline/exec.go
+++ b/action/pipeline/exec.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"slices"
 	"strings"
 	"syscall"
 
@@ -112,6 +113,61 @@ func (c *Config) Exec(client compiler.Engine) error {
 		Compile(context.Background(), path)
 	if err != nil {
 		return err
+	}
+
+	// create a slice for steps to be removed
+	stepsToRemove := c.Steps
+
+	// print steps to be removed to the user
+	if len(stepsToRemove) > 0 {
+		for _, stepName := range stepsToRemove {
+			fmt.Println("skip step: ", stepName)
+		}
+	}
+
+	// filter out steps to be removed
+	if len(_pipeline.Stages) > 0 {
+		// if using stages
+
+		// counter for total steps to run
+		totalSteps := 0
+
+		for i, stage := range _pipeline.Stages {
+
+			filteredStageSteps := stage.Steps[:0]
+
+			for _, step := range stage.Steps {
+				// if c.steps contains step.Name
+				if !slices.Contains(stepsToRemove, step.Name) {
+					filteredStageSteps = append(filteredStageSteps, step)
+					totalSteps++
+				}
+
+				_pipeline.Stages[i].Steps = filteredStageSteps
+			}
+		}
+
+		// check if any steps are left to run, excluding "init" step
+		if totalSteps <= 1 {
+			return fmt.Errorf("no steps left to run after removing skipped steps")
+		}
+
+	} else {
+		// if not using stages
+
+		filteredSteps := _pipeline.Steps[:0]
+
+		for _, step := range _pipeline.Steps {
+			if !slices.Contains(stepsToRemove, step.Name) {
+				filteredSteps = append(filteredSteps, step)
+			}
+		}
+		_pipeline.Steps = filteredSteps
+
+		// check if any steps are left to run, excluding "init" step
+		if len(_pipeline.Steps) <= 1 {
+			return fmt.Errorf("no steps left to run after removing skipped steps")
+		}
 	}
 
 	// create current directory path for local mount

--- a/action/pipeline/exec.go
+++ b/action/pipeline/exec.go
@@ -118,16 +118,8 @@ func (c *Config) Exec(client compiler.Engine) error {
 	// create a slice for steps to be removed
 	stepsToRemove := c.SkipSteps
 
-	// print steps to be removed to the user
-	if len(stepsToRemove) > 0 {
-		for _, stepName := range stepsToRemove {
-			fmt.Println("skip step: ", stepName)
-		}
-	}
-
 	// filter out steps to be removed
 	if len(_pipeline.Stages) > 0 {
-		// if using stages
 		// counter for total steps to run
 		totalSteps := 0
 
@@ -137,8 +129,6 @@ func (c *Config) Exec(client compiler.Engine) error {
 			for _, step := range stage.Steps {
 				// if c.steps contains step.Name
 				if !slices.Contains(stepsToRemove, step.Name) {
-					fmt.Println("skip step: ", stepsToRemove)
-
 					filteredStageSteps = append(filteredStageSteps, step)
 					totalSteps++
 				}
@@ -157,9 +147,14 @@ func (c *Config) Exec(client compiler.Engine) error {
 
 		for _, step := range _pipeline.Steps {
 			if !slices.Contains(stepsToRemove, step.Name) {
-				fmt.Println("skip step: ", stepsToRemove)
-
 				filteredSteps = append(filteredSteps, step)
+			}
+		}
+
+		// print steps to be removed to the user
+		if len(stepsToRemove) > 0 {
+			for _, stepName := range stepsToRemove {
+				fmt.Println("skip step5: ", stepName)
 			}
 		}
 

--- a/action/pipeline/exec.go
+++ b/action/pipeline/exec.go
@@ -128,11 +128,10 @@ func (c *Config) Exec(client compiler.Engine) error {
 	// filter out steps to be removed
 	if len(_pipeline.Stages) > 0 {
 		// if using stages
-
 		// counter for total steps to run
 		totalSteps := 0
-		for i, stage := range _pipeline.Stages {
 
+		for i, stage := range _pipeline.Stages {
 			filteredStageSteps := stage.Steps[:0]
 
 			for _, step := range stage.Steps {

--- a/action/pipeline/exec.go
+++ b/action/pipeline/exec.go
@@ -154,7 +154,7 @@ func (c *Config) Exec(client compiler.Engine) error {
 		// print steps to be removed to the user
 		if len(stepsToRemove) > 0 {
 			for _, stepName := range stepsToRemove {
-				fmt.Println("skip step5: ", stepName)
+				fmt.Println("skip step: ", stepName)
 			}
 		}
 

--- a/action/pipeline/pipeline.go
+++ b/action/pipeline/pipeline.go
@@ -16,7 +16,7 @@ type Config struct {
 	Target           string
 	Org              string
 	Repo             string
-	Steps            []string
+	SkipSteps        []string
 	Ref              string
 	File             string
 	FileChangeset    []string

--- a/action/pipeline/pipeline.go
+++ b/action/pipeline/pipeline.go
@@ -16,6 +16,7 @@ type Config struct {
 	Target           string
 	Org              string
 	Repo             string
+	Steps            []string
 	Ref              string
 	File             string
 	FileChangeset    []string

--- a/command/pipeline/exec.go
+++ b/command/pipeline/exec.go
@@ -134,6 +134,15 @@ var CommandExec = &cli.Command{
 			Value:   constants.PipelineTypeYAML,
 		},
 
+		// Step Flags
+
+		&cli.StringSliceFlag{
+			EnvVars: []string{"VELA_SKIP_STEP", "SKIP_STEP"},
+			Name:    "skip-step",
+			Aliases: []string{"sk", "skip"},
+			Usage:   "skip a step in the pipeline",
+		},
+
 		// Compiler Template Flags
 
 		&cli.StringFlag{
@@ -151,7 +160,7 @@ var CommandExec = &cli.Command{
 		&cli.StringSliceFlag{
 			EnvVars: []string{"VELA_TEMPLATE_FILE", "PIPELINE_TEMPLATE_FILE"},
 			Name:    "template-file",
-			Aliases: []string{"tf, tfs, template-files"},
+			Aliases: []string{"tf", "tfs", "template-files"},
 			Usage:   "enables using a local template file for expansion in the form <name>:<path>",
 		},
 		&cli.IntFlag{
@@ -218,17 +227,21 @@ EXAMPLES:
     $ {{.HelpName}} --volume /tmp/bar.txt:/tmp/bar.txt:rw
   7. Execute a local Vela pipeline with type of go
     $ {{.HelpName}} --pipeline-type go
-  8. Execute a local Vela pipeline with local templates
+  8. Execute a local Vela pipeline with specific step skipped
+    $ {{.HelpName}} --skip-step echo_hello --skip-step 'echo goodbye'
+  9. Execute a local Vela pipeline with specific template step skipped
+    $ {{.HelpName}} --skip-step <template name>_echo_hello --skip-step '<template name>_echo goodbye'
+  10. Execute a local Vela pipeline with local templates
     $ {{.HelpName}} --template-file <template_name>:<path_to_template>
-  9. Execute a local Vela pipeline with specific environment variables
+  11. Execute a local Vela pipeline with specific environment variables
     $ {{.HelpName}} --env KEY1=VAL1,KEY2=VAL2
-  10. Execute a local Vela pipeline with your existing local environment loaded into pipeline
+  12. Execute a local Vela pipeline with your existing local environment loaded into pipeline
     $ {{.HelpName}} --local-env
-  11. Execute a local Vela pipeline with an environment file loaded in
+  13. Execute a local Vela pipeline with an environment file loaded in
     $ {{.HelpName}} --env-file (uses .env by default)
       OR
     $ {{.HelpName}} --env-file-path <path_to_file>
-  12. Execute a local Vela pipeline using remote templates
+  14. Execute a local Vela pipeline using remote templates
     $ {{.HelpName}} --compiler.github.token <GITHUB_PAT> --compiler.github.url <GITHUB_URL>
 
 DOCUMENTATION:
@@ -296,6 +309,7 @@ func exec(c *cli.Context) error {
 		Target:           c.String("target"),
 		Org:              c.String(internal.FlagOrg),
 		Repo:             c.String(internal.FlagRepo),
+		Steps:            c.StringSlice("skip-step"),
 		File:             c.String("file"),
 		FileChangeset:    c.StringSlice("file-changeset"),
 		TemplateFiles:    c.StringSlice("template-file"),

--- a/command/pipeline/exec.go
+++ b/command/pipeline/exec.go
@@ -309,7 +309,7 @@ func exec(c *cli.Context) error {
 		Target:           c.String("target"),
 		Org:              c.String(internal.FlagOrg),
 		Repo:             c.String(internal.FlagRepo),
-		Steps:            c.StringSlice("skip-step"),
+		SkipSteps:        c.StringSlice("skip-step"),
 		File:             c.String("file"),
 		FileChangeset:    c.StringSlice("file-changeset"),
 		TemplateFiles:    c.StringSlice("template-file"),


### PR DESCRIPTION
Added flags for skipping steps:
https://github.com/go-vela/cli/blob/a51e7aa04061a5c6c811c0cb89ce4e6a16559947/command/pipeline/exec.go#L137-L144

Works for steps, stages, anchors, yaml templates, nested yaml templates.

- Stages: **any** steps with the provided name will be skipped, across all stages.
- Templates and nested templates: prepend the template name(s) to the step name
- Step names with spaces: wrap in quotes, including template name(s).

```
$ vela exec pipeline --sk echo_hi --sk child_echo_hi --sk 'child_some grandchild_echo_hi'
```

https://github.com/go-vela/cli/blob/a51e7aa04061a5c6c811c0cb89ce4e6a16559947/action/pipeline/exec.go#L118-L171

Also corrected punctuation for proper display in command help output:
https://github.com/go-vela/cli/blob/a51e7aa04061a5c6c811c0cb89ce4e6a16559947/command/pipeline/exec.go#L163