### PR TITLE
fix(renovate): container images

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,21 +1,16 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "local>go-vela/renovate-config"
-  ],
   "customManagers": [
     {
       "customType": "regex",
+      "description": "Manage container images used in urfave command default values",
       "managerFilePatterns": [
         "/\\.go$/"
       ],
       "matchStrings": [
-        "Value:\\s+\"(?<depName>[^\"]+):(?<currentValue>[^\"]+)@sha256:[a-f0-9]{64}\""
+        "Value:\\s+\"(?<depName>[^:\"]+):(?<currentValue>[^@\"]+)(@(?<currentDigest>sha256:[a-f0-9]+))?\""
       ],
-      "datasourceTemplate": "docker",
-      "depNameTemplate": "{{depName}}",
-      "versioningTemplate": "docker",
-      "extractVersionTemplate": "{{currentValue}}"
+      "datasourceTemplate": "docker"
     }
   ]
 }

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,5 +1,8 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "local>go-vela/renovate-config"
+  ],
   "customManagers": [
     {
       "customType": "regex",

--- a/command/pipeline/exec.go
+++ b/command/pipeline/exec.go
@@ -179,13 +179,13 @@ var CommandExec = &cli.Command{
 			Sources: cli.EnvVars("VELA_CLONE_IMAGE", "COMPILER_CLONE_IMAGE"),
 			Name:    "clone-image",
 			Usage:   "the clone image to use for the injected clone step",
-			Value:   "target/vela-git:v0.8.0@sha256:02de004ae9dbf184c70039cb9ce431c31d6e7580eb9e6ec64a97ebf108aa65cb",
+			Value:   "docker.io/target/vela-git-slim:v0.12.0@sha256:93cdb399e0a3150addac494198473c464c978ca055121593607097b75480192b",
 		},
 		&cli.StringFlag{
 			Sources: cli.EnvVars("VELA_OUTPUTS_IMAGE", "EXECUTOR_OUTPUTS_IMAGE"),
 			Name:    "outputs-image",
 			Usage:   "the outputs image to use for the build",
-			Value:   "library/alpine:3.21.3@sha256:a8560b36e8b8210634f77d9f7f9efd7ffa463e380b75e2e74aff4511df3ef88c",
+			Value:   "docker.io/library/alpine:3.21.3@sha256:a8560b36e8b8210634f77d9f7f9efd7ffa463e380b75e2e74aff4511df3ef88c",
 		},
 
 		// Environment Flags

--- a/command/pipeline/exec.go
+++ b/command/pipeline/exec.go
@@ -179,7 +179,7 @@ var CommandExec = &cli.Command{
 			Sources: cli.EnvVars("VELA_CLONE_IMAGE", "COMPILER_CLONE_IMAGE"),
 			Name:    "clone-image",
 			Usage:   "the clone image to use for the injected clone step",
-			Value:   "docker.io/target/vela-git-slim:v0.12.0@sha256:93cdb399e0a3150addac494198473c464c978ca055121593607097b75480192b",
+			Value:   "docker.io/target/vela-git-slim:v0.12.0@sha256:533786ab3ef17c900b0105fdffbd7143d2601803f28b39e156132ad25819af0f",
 		},
 		&cli.StringFlag{
 			Sources: cli.EnvVars("VELA_OUTPUTS_IMAGE", "EXECUTOR_OUTPUTS_IMAGE"),

--- a/command/pipeline/validate.go
+++ b/command/pipeline/validate.go
@@ -178,7 +178,7 @@ var CommandValidate = &cli.Command{
 			Sources:  cli.EnvVars("VELA_CLONE_IMAGE", "COMPILER_CLONE_IMAGE"),
 			Name:     "clone-image",
 			Usage:    "the clone image to use for the injected clone step",
-			Value:    "target/vela-git:v0.8.0@sha256:02de004ae9dbf184c70039cb9ce431c31d6e7580eb9e6ec64a97ebf108aa65cb",
+			Value:    "docker.io/target/vela-git-slim:v0.12.0@sha256:93cdb399e0a3150addac494198473c464c978ca055121593607097b75480192b",
 			Category: "4. Compiler:",
 		},
 	},

--- a/command/pipeline/validate.go
+++ b/command/pipeline/validate.go
@@ -178,7 +178,7 @@ var CommandValidate = &cli.Command{
 			Sources:  cli.EnvVars("VELA_CLONE_IMAGE", "COMPILER_CLONE_IMAGE"),
 			Name:     "clone-image",
 			Usage:    "the clone image to use for the injected clone step",
-			Value:    "docker.io/target/vela-git-slim:v0.12.0@sha256:93cdb399e0a3150addac494198473c464c978ca055121593607097b75480192b",
+			Value:    "docker.io/target/vela-git-slim:v0.12.0@sha256:533786ab3ef17c900b0105fdffbd7143d2601803f28b39e156132ad25819af0f",
 			Category: "4. Compiler:",
 		},
 	},


### PR DESCRIPTION
custom regex manager in renovate is supposed to update container images from `urfave` command defaults. however, git image is many versions behind. ran `renovate` locally via `LOG_LEVEL=debug npx renovate --platform=local --repository-cache=reset` to verify that it would intend to update these images with these new changes (had to temp remove the "extends" part for that to work).

also decided to include registry url for the image references.

> [!NOTE]
> git image is purposefully one patch version behind to verify the new config works. expect that renovate will want to update the git image on its next run.