### PR TITLE
fix(urfave): use new help var in help template

### DIFF
--- a/command/build/approve.go
+++ b/command/build/approve.go
@@ -49,9 +49,9 @@ var CommandApprove = &cli.Command{
 	CustomHelpTemplate: fmt.Sprintf(`%s
 EXAMPLES:
   1. Approve existing build for a repository.
-    $ {{.HelpName}} --org MyOrg --repo MyRepo --build 1
+    $ {{.FullName}} --org MyOrg --repo MyRepo --build 1
   2. Approve existing build for a repository when config or environment variables are set.
-    $ {{.HelpName}} --build 1
+    $ {{.FullName}} --build 1
 
 DOCUMENTATION:
 

--- a/command/build/cancel.go
+++ b/command/build/cancel.go
@@ -60,9 +60,9 @@ var CommandCancel = &cli.Command{
 	CustomHelpTemplate: fmt.Sprintf(`%s
 EXAMPLES:
   1. Cancel existing build for a repository.
-    $ {{.HelpName}} --org MyOrg --repo MyRepo --build 1
+    $ {{.FullName}} --org MyOrg --repo MyRepo --build 1
   2. Cancel existing build for a repository when config or environment variables are set.
-    $ {{.HelpName}} --build 1
+    $ {{.FullName}} --build 1
 
 DOCUMENTATION:
 

--- a/command/build/get.go
+++ b/command/build/get.go
@@ -101,23 +101,23 @@ var CommandGet = &cli.Command{
 	CustomHelpTemplate: fmt.Sprintf(`%s
 EXAMPLES:
   1. Get builds for a repository.
-    $ {{.HelpName}} --org MyOrg --repo MyRepo
+    $ {{.FullName}} --org MyOrg --repo MyRepo
   2. Get builds for a repository with the pull_request event.
-    $ {{.HelpName}} --org MyOrg --repo MyRepo --event pull_request
+    $ {{.FullName}} --org MyOrg --repo MyRepo --event pull_request
   3. Get builds for a repository with the status of success.
-    $ {{.HelpName}} --org MyOrg --repo MyRepo --status success
+    $ {{.FullName}} --org MyOrg --repo MyRepo --status success
   4. Get builds for a repository with the branch of main.
-    $ {{.HelpName}} --org MyOrg --repo MyRepo --branch main
+    $ {{.FullName}} --org MyOrg --repo MyRepo --branch main
   5. Get builds for a repository with wide view output.
-    $ {{.HelpName}} --org MyOrg --repo MyRepo --output wide
+    $ {{.FullName}} --org MyOrg --repo MyRepo --output wide
   6. Get builds for a repository with yaml output.
-    $ {{.HelpName}} --org MyOrg --repo MyRepo --output yaml
+    $ {{.FullName}} --org MyOrg --repo MyRepo --output yaml
   7. Get builds for a repository with json output.
-    $ {{.HelpName}} --org MyOrg --repo MyRepo --output json
+    $ {{.FullName}} --org MyOrg --repo MyRepo --output json
   8. Get builds for a repository when config or environment variables are set.
-    $ {{.HelpName}}
+    $ {{.FullName}}
   9. Get builds for a repository that were created before 1/2/22 & after 1/1/22.
-    $ {{.HelpName}} --org MyOrg --repo MyRepo --before 1641081600 --after 1640995200
+    $ {{.FullName}} --org MyOrg --repo MyRepo --before 1641081600 --after 1640995200
 
 DOCUMENTATION:
 

--- a/command/build/restart.go
+++ b/command/build/restart.go
@@ -60,9 +60,9 @@ var CommandRestart = &cli.Command{
 	CustomHelpTemplate: fmt.Sprintf(`%s
 EXAMPLES:
   1. Restart existing build for a repository.
-    $ {{.HelpName}} --org MyOrg --repo MyRepo --build 1
+    $ {{.FullName}} --org MyOrg --repo MyRepo --build 1
   2. Restart existing build for a repository when config or environment variables are set.
-    $ {{.HelpName}} --build 1
+    $ {{.FullName}} --build 1
 
 DOCUMENTATION:
 

--- a/command/build/view.go
+++ b/command/build/view.go
@@ -60,11 +60,11 @@ var CommandView = &cli.Command{
 	CustomHelpTemplate: fmt.Sprintf(`%s
 EXAMPLES:
   1. View build details for a repository.
-    $ {{.HelpName}} --org MyOrg --repo MyRepo --build 1
+    $ {{.FullName}} --org MyOrg --repo MyRepo --build 1
   2. View build details for a repository with json output.
-    $ {{.HelpName}} --org MyOrg --repo MyRepo --build 1 --output json
+    $ {{.FullName}} --org MyOrg --repo MyRepo --build 1 --output json
   3. View build details for a repository when config or environment variables are set.
-    $ {{.HelpName}} --build 1
+    $ {{.FullName}} --build 1
 
 DOCUMENTATION:
 

--- a/command/completion/generate.go
+++ b/command/completion/generate.go
@@ -41,9 +41,9 @@ var CommandGenerate = &cli.Command{
 	CustomHelpTemplate: fmt.Sprintf(`%s
 EXAMPLES:
   1. Enable auto completion for the current bash session.
-    $ source <({{.HelpName}} --bash true)
+    $ source <({{.FullName}} --bash true)
   2. Enable auto completion for the current zsh session.
-    $ source <({{.HelpName}} --zsh true)
+    $ source <({{.FullName}} --zsh true)
   3. Enable auto completion for bash permanently.
     visit https://go-vela.github.io/docs/reference/cli/completion/generate/#bash
   4. Enable auto completion for zsh permanently.

--- a/command/config/generate.go
+++ b/command/config/generate.go
@@ -129,15 +129,15 @@ var CommandGenerate = &cli.Command{
 	CustomHelpTemplate: fmt.Sprintf(`%s
 EXAMPLES:
   1. Generate the config file with a Vela server address.
-    $ {{.HelpName}} --api.addr https://vela.example.com
+    $ {{.FullName}} --api.addr https://vela.example.com
   2. Generate the config file with Vela server token.
-    $ {{.HelpName}} --api.token fakeToken
+    $ {{.FullName}} --api.token fakeToken
   3. Generate the config file with secret engine and type.
-    $ {{.HelpName}} --secret.engine native --secret.type org
+    $ {{.FullName}} --secret.engine native --secret.type org
   4. Generate the config file with trace level logging.
-    $ {{.HelpName}} --log.level trace
+    $ {{.FullName}} --log.level trace
   5. Generate the config file when environment variables are set.
-    $ {{.HelpName}}
+    $ {{.FullName}}
 
 DOCUMENTATION:
 

--- a/command/config/remove.go
+++ b/command/config/remove.go
@@ -151,15 +151,15 @@ var CommandRemove = &cli.Command{
 	CustomHelpTemplate: fmt.Sprintf(`%s
 EXAMPLES:
   1. Remove the config file.
-    $ {{.HelpName}}
+    $ {{.FullName}}
   2. Remove the addr field from the config file.
-    $ {{.HelpName}} --api.addr true
+    $ {{.FullName}} --api.addr true
   3. Remove the token field from the config file.
-    $ {{.HelpName}} --api.token true
+    $ {{.FullName}} --api.token true
   4. Remove the secret engine and type fields from the config file.
-    $ {{.HelpName}} --secret.engine true --secret.type true
+    $ {{.FullName}} --secret.engine true --secret.type true
   5. Remove the log level field from the config file.
-    $ {{.HelpName}} --log.level true
+    $ {{.FullName}} --log.level true
 
 DOCUMENTATION:
 

--- a/command/config/update.go
+++ b/command/config/update.go
@@ -137,17 +137,17 @@ var CommandUpdate = &cli.Command{
 	CustomHelpTemplate: fmt.Sprintf(`%s
 EXAMPLES:
   1. Update the addr field in the config file.
-    $ {{.HelpName}} --api.addr https://vela.example.com
+    $ {{.FullName}} --api.addr https://vela.example.com
   2. Update the token field in the config file.
-    $ {{.HelpName}} --api.token fakeToken
+    $ {{.FullName}} --api.token fakeToken
   3. Update the secret engine and type fields in the config file.
-    $ {{.HelpName}} --secret.engine native --secret.type org
+    $ {{.FullName}} --secret.engine native --secret.type org
   4. Update the log level field in the config file.
-    $ {{.HelpName}} --log.level trace
+    $ {{.FullName}} --log.level trace
   5. Update the no git field in the config file.
-    $ {{.HelpName}} --no-git bool
+    $ {{.FullName}} --no-git bool
   6. Update the config file when environment variables are set.
-    $ {{.HelpName}}
+    $ {{.FullName}}
 
 DOCUMENTATION:
 

--- a/command/config/view.go
+++ b/command/config/view.go
@@ -29,7 +29,7 @@ var CommandView = &cli.Command{
 	CustomHelpTemplate: fmt.Sprintf(`%s
 EXAMPLES:
   1. View the config file.
-    $ {{.HelpName}}
+    $ {{.FullName}}
 
 DOCUMENTATION:
 

--- a/command/dashboard/add.go
+++ b/command/dashboard/add.go
@@ -66,13 +66,13 @@ var CommandAdd = &cli.Command{
 	CustomHelpTemplate: fmt.Sprintf(`%s
 EXAMPLES:
   1. Add a dashboard.
-    $ {{.HelpName}} --name my-dashboard
+    $ {{.FullName}} --name my-dashboard
   2. Add a dashboard with repositories.
-    $ {{.HelpName}} --name my-dashboard --repos Org-1/Repo-1,Org-2/Repo-2
+    $ {{.FullName}} --name my-dashboard --repos Org-1/Repo-1,Org-2/Repo-2
   3. Add a dashboard with repositories filtering builds by pushes to main.
-    $ {{.HelpName}} --name my-dashboard --repos Org-1/Repo-1,Org-2/Repo-2 --branch main --event push
+    $ {{.FullName}} --name my-dashboard --repos Org-1/Repo-1,Org-2/Repo-2 --branch main --event push
   4. Add a dashboard with multiple admins.
-    $ {{.HelpName}} --name my-dashboard --admins JohnDoe,JaneDoe
+    $ {{.FullName}} --name my-dashboard --admins JohnDoe,JaneDoe
 
 DOCUMENTATION:
 

--- a/command/dashboard/get.go
+++ b/command/dashboard/get.go
@@ -40,9 +40,9 @@ var CommandGet = &cli.Command{
 	CustomHelpTemplate: fmt.Sprintf(`%s
 EXAMPLES:
   1. Get user dashboards.
-    $ {{.HelpName}}
+    $ {{.FullName}}
   2. Get user dashboards with repo and build information.
-    $ {{.HelpName}} --full
+    $ {{.FullName}} --full
 
 DOCUMENTATION:
 

--- a/command/dashboard/update.go
+++ b/command/dashboard/update.go
@@ -85,17 +85,17 @@ var CommandUpdate = &cli.Command{
 	CustomHelpTemplate: fmt.Sprintf(`%s
 EXAMPLES:
   1. Update a dashboard to add a repository.
-    $ {{.HelpName}} --id c8da1302-07d6-11ea-882f-4893bca275b8 --add-repos Org-1/Repo-1
+    $ {{.FullName}} --id c8da1302-07d6-11ea-882f-4893bca275b8 --add-repos Org-1/Repo-1
   2. Update a dashboard to remove a repository.
-    $ {{.HelpName}} --id c8da1302-07d6-11ea-882f-4893bca275b8 --drop-repos Org-1/Repo-1
+    $ {{.FullName}} --id c8da1302-07d6-11ea-882f-4893bca275b8 --drop-repos Org-1/Repo-1
   3. Update a dashboard to add event and branch filters to specific repositories.
-    $ {{.HelpName}} --id c8da1302-07d6-11ea-882f-4893bca275b8 --target-repos Org-1/Repo-1,Org-2/Repo-2 --branches main --events push
+    $ {{.FullName}} --id c8da1302-07d6-11ea-882f-4893bca275b8 --target-repos Org-1/Repo-1,Org-2/Repo-2 --branches main --events push
   4. Update a dashboard to change the name.
-    $ {{.HelpName}} --id c8da1302-07d6-11ea-882f-4893bca275b8 --name MyDashboard
+    $ {{.FullName}} --id c8da1302-07d6-11ea-882f-4893bca275b8 --name MyDashboard
   5. Update a dashboard to add an admin.
-    $ {{.HelpName}} --id c8da1302-07d6-11ea-882f-4893bca275b8 --add-admins JohnDoe
+    $ {{.FullName}} --id c8da1302-07d6-11ea-882f-4893bca275b8 --add-admins JohnDoe
   6. Update a dashboard to remove an admin.
-    $ {{.HelpName}} --id c8da1302-07d6-11ea-882f-4893bca275b8 --drop-admins JohnDoe
+    $ {{.FullName}} --id c8da1302-07d6-11ea-882f-4893bca275b8 --drop-admins JohnDoe
 
 DOCUMENTATION:
 

--- a/command/dashboard/view.go
+++ b/command/dashboard/view.go
@@ -48,9 +48,9 @@ var CommandView = &cli.Command{
 	CustomHelpTemplate: fmt.Sprintf(`%s
 EXAMPLES:
   1. View a dashboard.
-    $ {{.HelpName}} --id c8da1302-07d6-11ea-882f-4893bca275b8
+    $ {{.FullName}} --id c8da1302-07d6-11ea-882f-4893bca275b8
   2. View a dashboard with repo and build information.
-    $ {{.HelpName}} --id c8da1302-07d6-11ea-882f-4893bca275b8 --full
+    $ {{.FullName}} --id c8da1302-07d6-11ea-882f-4893bca275b8 --full
 
 DOCUMENTATION:
 

--- a/command/deployment/add.go
+++ b/command/deployment/add.go
@@ -94,23 +94,23 @@ var CommandAdd = &cli.Command{
 	CustomHelpTemplate: fmt.Sprintf(`%s
 EXAMPLES:
   1. Add a deployment for a repository.
-    $ {{.HelpName}} --org MyOrg --repo MyRepo
+    $ {{.FullName}} --org MyOrg --repo MyRepo
   2. Add a deployment for a repository with a specific target environment.
-    $ {{.HelpName}} --org MyOrg --repo MyRepo --target stage
+    $ {{.FullName}} --org MyOrg --repo MyRepo --target stage
   3. Add a deployment for a repository with a specific branch reference.
-    $ {{.HelpName}} --org MyOrg --repo MyRepo --ref dev
+    $ {{.FullName}} --org MyOrg --repo MyRepo --ref dev
   4. Add a deployment for a repository with a specific commit reference.
-    $ {{.HelpName}} --org MyOrg --repo MyRepo --ref 48afb5bdc41ad69bf22588491333f7cf71135163
+    $ {{.FullName}} --org MyOrg --repo MyRepo --ref 48afb5bdc41ad69bf22588491333f7cf71135163
   5. Add a deployment for a repository with a specific tag reference.
-    $ {{.HelpName}} --org MyOrg --repo MyRepo --ref refs/tags/1.0.0
+    $ {{.FullName}} --org MyOrg --repo MyRepo --ref refs/tags/1.0.0
   6. Add a deployment for a repository with a specific description.
-    $ {{.HelpName}} --org MyOrg --repo MyRepo --description 'my custom message'
+    $ {{.FullName}} --org MyOrg --repo MyRepo --description 'my custom message'
   7. Add a deployment for a repository with two parameters.
-    $ {{.HelpName}} --org MyOrg --repo MyRepo --parameter 'key=value' --parameter 'foo=bar'
+    $ {{.FullName}} --org MyOrg --repo MyRepo --parameter 'key=value' --parameter 'foo=bar'
   8. Add a deployment for a repository with a parameters JSON file.
-    $ {{.HelpName}} --org MyOrg --repo MyRepo --parameters-file params.json
+    $ {{.FullName}} --org MyOrg --repo MyRepo --parameters-file params.json
   9. Add a deployment for a repository when config or environment variables are set.
-    $ {{.HelpName}}
+    $ {{.FullName}}
 
 DOCUMENTATION:
 

--- a/command/deployment/get.go
+++ b/command/deployment/get.go
@@ -68,15 +68,15 @@ var CommandGet = &cli.Command{
 	CustomHelpTemplate: fmt.Sprintf(`%s
 EXAMPLES:
   1. Get deployments for a repository.
-    $ {{.HelpName}} --org MyOrg --repo MyRepo
+    $ {{.FullName}} --org MyOrg --repo MyRepo
   2. Get deployments for a repository with wide view output.
-    $ {{.HelpName}} --org MyOrg --repo MyRepo --output wide
+    $ {{.FullName}} --org MyOrg --repo MyRepo --output wide
   3. Get deployments for a repository with yaml output.
-    $ {{.HelpName}} --org MyOrg --repo MyRepo --output yaml
+    $ {{.FullName}} --org MyOrg --repo MyRepo --output yaml
   4. Get deployments for a repository with json output.
-    $ {{.HelpName}} --org MyOrg --repo MyRepo --output json
+    $ {{.FullName}} --org MyOrg --repo MyRepo --output json
   5. Get deployments for a repository when config or environment variables are set.
-    $ {{.HelpName}}
+    $ {{.FullName}}
 
 DOCUMENTATION:
 

--- a/command/deployment/view.go
+++ b/command/deployment/view.go
@@ -60,11 +60,11 @@ var CommandView = &cli.Command{
 	CustomHelpTemplate: fmt.Sprintf(`%s
 EXAMPLES:
   1. View deployment details for a repository.
-    $ {{.HelpName}} --org MyOrg --repo MyRepo --deployment 1
+    $ {{.FullName}} --org MyOrg --repo MyRepo --deployment 1
   2. View deployment details for a repository with json output.
-    $ {{.HelpName}} --org MyOrg --repo MyRepo --deployment 1 --output json
+    $ {{.FullName}} --org MyOrg --repo MyRepo --deployment 1 --output json
   3. View deployment details for a repository config or environment variables are set.
-    $ {{.HelpName}} --deployment 1
+    $ {{.FullName}} --deployment 1
 
 DOCUMENTATION:
 

--- a/command/docs/generate.go
+++ b/command/docs/generate.go
@@ -42,9 +42,9 @@ var CommandGenerate = &cli.Command{
 	CustomHelpTemplate: fmt.Sprintf(`%s
 EXAMPLES:
   1. Generate markdown docs for the CLI.
-    $ source <({{.HelpName}} --markdown true)
+    $ source <({{.FullName}} --markdown true)
   2. Generate man page docs for the CLI.
-    $ source <({{.HelpName}} --man true)
+    $ source <({{.FullName}} --man true)
 
 DOCUMENTATION:
 

--- a/command/hook/get.go
+++ b/command/hook/get.go
@@ -68,15 +68,15 @@ var CommandGet = &cli.Command{
 	CustomHelpTemplate: fmt.Sprintf(`%s
 EXAMPLES:
   1. Get hooks for a repository.
-    $ {{.HelpName}} --org MyOrg --repo MyRepo
+    $ {{.FullName}} --org MyOrg --repo MyRepo
   2. Get hooks for a repository with wide view output.
-    $ {{.HelpName}} --org MyOrg --repo MyRepo --output wide
+    $ {{.FullName}} --org MyOrg --repo MyRepo --output wide
   3. Get hooks for a repository with yaml output.
-    $ {{.HelpName}} --org MyOrg --repo MyRepo --output yaml
+    $ {{.FullName}} --org MyOrg --repo MyRepo --output yaml
   4. Get hooks for a repository with json output.
-    $ {{.HelpName}} --org MyOrg --repo MyRepo --output json
+    $ {{.FullName}} --org MyOrg --repo MyRepo --output json
   5. Get hooks for a repository when config or environment variables are set.
-    $ {{.HelpName}}
+    $ {{.FullName}}
 
 DOCUMENTATION:
 

--- a/command/hook/view.go
+++ b/command/hook/view.go
@@ -60,11 +60,11 @@ var CommandView = &cli.Command{
 	CustomHelpTemplate: fmt.Sprintf(`%s
 EXAMPLES:
   1. View hook details for a repository.
-    $ {{.HelpName}} --org MyOrg --repo MyRepo --hook 1
+    $ {{.FullName}} --org MyOrg --repo MyRepo --hook 1
   2. View hook details for a repository with json output.
-    $ {{.HelpName}} --org MyOrg --repo MyRepo --hook 1 --output json
+    $ {{.FullName}} --org MyOrg --repo MyRepo --hook 1 --output json
   3. View hook details for a repository when config or environment variables are set.
-    $ {{.HelpName}} --hook 1
+    $ {{.FullName}} --hook 1
 
 DOCUMENTATION:
 

--- a/command/log/get.go
+++ b/command/log/get.go
@@ -77,13 +77,13 @@ var CommandGet = &cli.Command{
 	CustomHelpTemplate: fmt.Sprintf(`%s
 EXAMPLES:
   1. Get logs for a build.
-    $ {{.HelpName}} --org MyOrg --repo MyRepo --build 1
+    $ {{.FullName}} --org MyOrg --repo MyRepo --build 1
   2. Get logs for a build with yaml output.
-    $ {{.HelpName}} --org MyOrg --repo MyRepo --build 1 --output yaml
+    $ {{.FullName}} --org MyOrg --repo MyRepo --build 1 --output yaml
   3. Get logs for a build with json output.
-    $ {{.HelpName}} --org MyOrg --repo MyRepo --build 1 --output json
+    $ {{.FullName}} --org MyOrg --repo MyRepo --build 1 --output json
   4. Get logs for a build when config or environment variables are set.
-    $ {{.HelpName}} --build 1
+    $ {{.FullName}} --build 1
 
 DOCUMENTATION:
 

--- a/command/log/view.go
+++ b/command/log/view.go
@@ -75,17 +75,17 @@ var CommandView = &cli.Command{
 	CustomHelpTemplate: fmt.Sprintf(`%s
 EXAMPLES:
   1. View logs for a build.
-    $ {{.HelpName}} --org MyOrg --repo MyRepo --build 1
+    $ {{.FullName}} --org MyOrg --repo MyRepo --build 1
   2. View logs for a service.
-    $ {{.HelpName}} --org MyOrg --repo MyRepo --build 1 --service 1
+    $ {{.FullName}} --org MyOrg --repo MyRepo --build 1 --service 1
   3. View logs for a step.
-    $ {{.HelpName}} --org MyOrg --repo MyRepo --build 1 --step 1
+    $ {{.FullName}} --org MyOrg --repo MyRepo --build 1 --step 1
   4. View logs for a build with yaml output.
-    $ {{.HelpName}} --org MyOrg --repo MyRepo --build 1 --output yaml
+    $ {{.FullName}} --org MyOrg --repo MyRepo --build 1 --output yaml
   5. View logs for a build with json output.
-    $ {{.HelpName}} --org MyOrg --repo MyRepo --build 1 --output json
+    $ {{.FullName}} --org MyOrg --repo MyRepo --build 1 --output json
   6. View logs for a build when config or environment variables are set.
-    $ {{.HelpName}} --build 1
+    $ {{.FullName}} --build 1
 
 DOCUMENTATION:
 

--- a/command/login/login.go
+++ b/command/login/login.go
@@ -69,7 +69,7 @@ var CommandLogin = &cli.Command{
 	CustomHelpTemplate: fmt.Sprintf(`%s
 EXAMPLES:
   1. Login to Vela (will launch browser).
-    $ {{.HelpName}} --api.addr https://vela.example.com
+    $ {{.FullName}} --api.addr https://vela.example.com
 
 DOCUMENTATION:
 

--- a/command/pipeline/compile.go
+++ b/command/pipeline/compile.go
@@ -61,11 +61,11 @@ var CommandCompile = &cli.Command{
 	CustomHelpTemplate: fmt.Sprintf(`%s
 EXAMPLES:
   1. Compile a pipeline for a repository.
-    $ {{.HelpName}} --org MyOrg --repo MyRepo
+    $ {{.FullName}} --org MyOrg --repo MyRepo
   2. Compile a pipeline for a repository with json output.
-    $ {{.HelpName}} --org MyOrg --repo MyRepo --output json
+    $ {{.FullName}} --org MyOrg --repo MyRepo --output json
   3. Compile a pipeline for a repository when config or environment variables are set.
-    $ {{.HelpName}}
+    $ {{.FullName}}
 
 DOCUMENTATION:
 

--- a/command/pipeline/exec.go
+++ b/command/pipeline/exec.go
@@ -218,35 +218,35 @@ var CommandExec = &cli.Command{
 	CustomHelpTemplate: fmt.Sprintf(`%s
 EXAMPLES:
   1. Execute a local Vela pipeline.
-    $ {{.HelpName}}
+    $ {{.FullName}}
   2. Execute a local Vela pipeline in a nested directory.
-    $ {{.HelpName}} --path nested/path/to/dir --file .vela.local.yml
+    $ {{.FullName}} --path nested/path/to/dir --file .vela.local.yml
   3. Execute a local Vela pipeline in a specific directory.
-    $ {{.HelpName}} --path /absolute/full/path/to/dir --file .vela.local.yml
+    $ {{.FullName}} --path /absolute/full/path/to/dir --file .vela.local.yml
   4. Execute a local Vela pipeline with ruleset information.
-    $ {{.HelpName}} --branch main --event push
+    $ {{.FullName}} --branch main --event push
   5. Execute a local Vela pipeline with a read-only local volume.
-    $ {{.HelpName}} --volume /tmp/foo.txt:/tmp/foo.txt:ro
+    $ {{.FullName}} --volume /tmp/foo.txt:/tmp/foo.txt:ro
   6. Execute a local Vela pipeline with a writeable local volume.
-    $ {{.HelpName}} --volume /tmp/bar.txt:/tmp/bar.txt:rw
+    $ {{.FullName}} --volume /tmp/bar.txt:/tmp/bar.txt:rw
   7. Execute a local Vela pipeline with type of go
-    $ {{.HelpName}} --pipeline-type go
+    $ {{.FullName}} --pipeline-type go
   8. Execute a local Vela pipeline with specific step skipped
-    $ {{.HelpName}} --skip-step echo_hello --skip-step 'echo goodbye'
+    $ {{.FullName}} --skip-step echo_hello --skip-step 'echo goodbye'
   9. Execute a local Vela pipeline with specific template step skipped
-    $ {{.HelpName}} --skip-step <template name>_echo_hello --skip-step '<template name>_echo goodbye'
+    $ {{.FullName}} --skip-step <template name>_echo_hello --skip-step '<template name>_echo goodbye'
   10. Execute a local Vela pipeline with local templates
-    $ {{.HelpName}} --template-file <template_name>:<path_to_template>
+    $ {{.FullName}} --template-file <template_name>:<path_to_template>
   11. Execute a local Vela pipeline with specific environment variables
-    $ {{.HelpName}} --env KEY1=VAL1,KEY2=VAL2
+    $ {{.FullName}} --env KEY1=VAL1,KEY2=VAL2
   12. Execute a local Vela pipeline with your existing local environment loaded into pipeline
-    $ {{.HelpName}} --local-env
+    $ {{.FullName}} --local-env
   13. Execute a local Vela pipeline with an environment file loaded in
-    $ {{.HelpName}} --env-file (uses .env by default)
+    $ {{.FullName}} --env-file (uses .env by default)
       OR
-    $ {{.HelpName}} --env-file-path <path_to_file>
+    $ {{.FullName}} --env-file-path <path_to_file>
   14. Execute a local Vela pipeline using remote templates
-    $ {{.HelpName}} --compiler.github.token <GITHUB_PAT> --compiler.github.url <GITHUB_URL>
+    $ {{.FullName}} --compiler.github.token <GITHUB_PAT> --compiler.github.url <GITHUB_URL>
 
 DOCUMENTATION:
 

--- a/command/pipeline/expand.go
+++ b/command/pipeline/expand.go
@@ -61,11 +61,11 @@ var CommandExpand = &cli.Command{
 	CustomHelpTemplate: fmt.Sprintf(`%s
 EXAMPLES:
   1. Expand a pipeline for a repository.
-    $ {{.HelpName}} --org MyOrg --repo MyRepo
+    $ {{.FullName}} --org MyOrg --repo MyRepo
   2. Expand a pipeline for a repository with json output.
-    $ {{.HelpName}} --org MyOrg --repo MyRepo --output json
+    $ {{.FullName}} --org MyOrg --repo MyRepo --output json
   3. Expand a pipeline for a repository when config or environment variables are set.
-    $ {{.HelpName}}
+    $ {{.FullName}}
 
 DOCUMENTATION:
 

--- a/command/pipeline/generate.go
+++ b/command/pipeline/generate.go
@@ -52,19 +52,19 @@ var CommandGenerate = &cli.Command{
 	CustomHelpTemplate: fmt.Sprintf(`%s
 EXAMPLES:
   1. Generate a Vela pipeline.
-    $ {{.HelpName}}
+    $ {{.FullName}}
   2. Generate a Vela pipeline in a nested directory.
-    $ {{.HelpName}} --path nested/path/to/dir
+    $ {{.FullName}} --path nested/path/to/dir
   3. Generate a Vela pipeline in a specific directory.
-    $ {{.HelpName}} --path /absolute/full/path/to/dir
+    $ {{.FullName}} --path /absolute/full/path/to/dir
   4. Generate a Vela pipeline with stages.
-    $ {{.HelpName}} --stages true
+    $ {{.FullName}} --stages true
   5. Generate a go Vela pipeline.
-    $ {{.HelpName}} --secret.type go
+    $ {{.FullName}} --secret.type go
   6. Generate a java Vela pipeline.
-    $ {{.HelpName}} --secret.type java
+    $ {{.FullName}} --secret.type java
   7. Generate a node Vela pipeline.
-    $ {{.HelpName}} --secret.type node
+    $ {{.FullName}} --secret.type node
 
 DOCUMENTATION:
 

--- a/command/pipeline/get.go
+++ b/command/pipeline/get.go
@@ -68,15 +68,15 @@ var CommandGet = &cli.Command{
 	CustomHelpTemplate: fmt.Sprintf(`%s
 EXAMPLES:
   1. Get pipelines for a repository.
-    $ {{.HelpName}} --org MyOrg --repo MyRepo
+    $ {{.FullName}} --org MyOrg --repo MyRepo
   2. Get pipelines for a repository with wide view output.
-    $ {{.HelpName}} --org MyOrg --repo MyRepo --output wide
+    $ {{.FullName}} --org MyOrg --repo MyRepo --output wide
   3. Get pipelines for a repository with yaml output.
-    $ {{.HelpName}} --org MyOrg --repo MyRepo --output yaml
+    $ {{.FullName}} --org MyOrg --repo MyRepo --output yaml
   4. Get pipelines for a repository with json output.
-    $ {{.HelpName}} --org MyOrg --repo MyRepo --output json
+    $ {{.FullName}} --org MyOrg --repo MyRepo --output json
   5. Get pipelines for a repository when config or environment variables are set.
-    $ {{.HelpName}}
+    $ {{.FullName}}
 
 DOCUMENTATION:
 

--- a/command/pipeline/validate.go
+++ b/command/pipeline/validate.go
@@ -185,23 +185,23 @@ var CommandValidate = &cli.Command{
 	CustomHelpTemplate: fmt.Sprintf(`%s
 EXAMPLES:
   1. Validate a local Vela pipeline.
-    $ {{.HelpName}}
+    $ {{.FullName}}
   2. Validate a local Vela pipeline in a nested directory.
-    $ {{.HelpName}} --path nested/path/to/dir
+    $ {{.FullName}} --path nested/path/to/dir
   3. Validate a local Vela pipeline in a specific directory.
-    $ {{.HelpName}} --path /absolute/full/path/to/dir
+    $ {{.FullName}} --path /absolute/full/path/to/dir
   4. Validate a remote pipeline for a repository.
-    $ {{.HelpName}} --remote --org MyOrg --repo MyRepo
+    $ {{.FullName}} --remote --org MyOrg --repo MyRepo
   5. Validate a remote pipeline for a repository with json output.
-    $ {{.HelpName}} --remote --org MyOrg --repo MyRepo --output json
+    $ {{.FullName}} --remote --org MyOrg --repo MyRepo --output json
   6. Validate a template pipeline with expanding steps (when templates are sourced from private Github instance)
-    $ {{.HelpName}} --compiler.github.token <token> --compiler.github.url <url>
+    $ {{.FullName}} --compiler.github.token <token> --compiler.github.url <url>
   7. Validate a pipeline with ruleset data
-    $ {{.HelpName}} --branch dev --event push
+    $ {{.FullName}} --branch dev --event push
   8. Validate a local template pipeline with expanding steps
-    $ {{.HelpName}} --template-file name:/path/to/file
+    $ {{.FullName}} --template-file name:/path/to/file
   9. Validate a local, nested template pipeline with custom template depth.
-    $ {{.HelpName}} --template-file name:/path/to/file name:/path/to/file --max-template-depth 2
+    $ {{.FullName}} --template-file name:/path/to/file name:/path/to/file --max-template-depth 2
 DOCUMENTATION:
 
   https://go-vela.github.io/docs/reference/cli/pipeline/validate/

--- a/command/pipeline/view.go
+++ b/command/pipeline/view.go
@@ -59,11 +59,11 @@ var CommandView = &cli.Command{
 	CustomHelpTemplate: fmt.Sprintf(`%s
 EXAMPLES:
   1. View details of a pipeline for a repository.
-    $ {{.HelpName}} --org MyOrg --repo MyRepo --ref MyCommitSHA
+    $ {{.FullName}} --org MyOrg --repo MyRepo --ref MyCommitSHA
   2. View details of a pipeline for a repository with json output.
-    $ {{.HelpName}} --org MyOrg --repo MyRepo --ref MyCommitSHA
+    $ {{.FullName}} --org MyOrg --repo MyRepo --ref MyCommitSHA
   3. View details of a pipeline for a repository when config or environment variables are set.
-    $ {{.HelpName}}
+    $ {{.FullName}}
 
 DOCUMENTATION:
 

--- a/command/repo/add.go
+++ b/command/repo/add.go
@@ -136,19 +136,19 @@ var CommandAdd = &cli.Command{
 	CustomHelpTemplate: fmt.Sprintf(`%s
 EXAMPLES:
   1. Add a repository with push and pull request enabled.
-    $ {{.HelpName}} --org MyOrg --repo MyRepo --event push --event pull_request
+    $ {{.FullName}} --org MyOrg --repo MyRepo --event push --event pull_request
   2. Add a repository with all event types enabled.
-    $ {{.HelpName}} --org MyOrg --repo MyRepo --event push --event pull_request --event tag --event deployment --event comment
+    $ {{.FullName}} --org MyOrg --repo MyRepo --event push --event pull_request --event tag --event deployment --event comment
   3. Add a repository with a longer build timeout.
-    $ {{.HelpName}} --org MyOrg --repo MyRepo --timeout 90
+    $ {{.FullName}} --org MyOrg --repo MyRepo --timeout 90
   4. Add a repository when config or environment variables are set.
-    $ {{.HelpName}} --event push --event pull_request
+    $ {{.FullName}} --event push --event pull_request
   5. Add a repository with a starting build number.
-    $ {{.HelpName}} --org MyOrg --repo MyRepo --counter 90
+    $ {{.FullName}} --org MyOrg --repo MyRepo --counter 90
   6. Add a repository with a starlark pipeline file.
-    $ {{.HelpName}} --org MyOrg --repo MyRepo --pipeline-type starlark
+    $ {{.FullName}} --org MyOrg --repo MyRepo --pipeline-type starlark
   7. Add a repository with approve build setting set to fork-no-write.
-    $ {{.HelpName}} --org MyOrg --repo MyRepo --approve-build fork-no-write
+    $ {{.FullName}} --org MyOrg --repo MyRepo --approve-build fork-no-write
 
 DOCUMENTATION:
 

--- a/command/repo/chown.go
+++ b/command/repo/chown.go
@@ -51,11 +51,11 @@ var CommandChown = &cli.Command{
 	CustomHelpTemplate: fmt.Sprintf(`%s
 EXAMPLES:
   1. Change ownership of a repository.
-    $ {{.HelpName}} --org MyOrg --repo MyRepo
+    $ {{.FullName}} --org MyOrg --repo MyRepo
   2. Change ownership of a repository with json output.
-    $ {{.HelpName}} --org MyOrg --repo MyRepo --output json
+    $ {{.FullName}} --org MyOrg --repo MyRepo --output json
   3. Change ownership of a repository when config or environment variables are set.
-    $ {{.HelpName}}
+    $ {{.FullName}}
 
 DOCUMENTATION:
 

--- a/command/repo/get.go
+++ b/command/repo/get.go
@@ -53,15 +53,15 @@ var CommandGet = &cli.Command{
 	CustomHelpTemplate: fmt.Sprintf(`%s
 EXAMPLES:
   1. Get a list of repositories.
-    $ {{.HelpName}}
+    $ {{.FullName}}
   2. Get a list of repositories with wide view output.
-    $ {{.HelpName}} --output wide
+    $ {{.FullName}} --output wide
   3. Get a list of repositories with yaml output.
-    $ {{.HelpName}} --output yaml
+    $ {{.FullName}} --output yaml
   4. Get a list of repositories with json output.
-    $ {{.HelpName}} --output json
+    $ {{.FullName}} --output json
   5. Get a list of repositories when config or environment variables are set.
-    $ {{.HelpName}}
+    $ {{.FullName}}
 
 DOCUMENTATION:
 

--- a/command/repo/remove.go
+++ b/command/repo/remove.go
@@ -51,11 +51,11 @@ var CommandRemove = &cli.Command{
 	CustomHelpTemplate: fmt.Sprintf(`%s
 EXAMPLES:
   1. Remove a repository.
-    $ {{.HelpName}} --org MyOrg --repo MyRepo
+    $ {{.FullName}} --org MyOrg --repo MyRepo
   2. Remove a repository with json output.
-    $ {{.HelpName}} --org MyOrg --repo MyRepo --output json
+    $ {{.FullName}} --org MyOrg --repo MyRepo --output json
   3. Remove a repository when config or environment variables are set.
-    $ {{.HelpName}}
+    $ {{.FullName}}
 
 DOCUMENTATION:
 

--- a/command/repo/repair.go
+++ b/command/repo/repair.go
@@ -51,11 +51,11 @@ var CommandRepair = &cli.Command{
 	CustomHelpTemplate: fmt.Sprintf(`%s
 EXAMPLES:
   1. Repair a damaged repository.
-    $ {{.HelpName}} --org MyOrg --repo MyRepo
+    $ {{.FullName}} --org MyOrg --repo MyRepo
   2. Repair a damaged repository with json output.
-    $ {{.HelpName}} --org MyOrg --repo MyRepo --output json
+    $ {{.FullName}} --org MyOrg --repo MyRepo --output json
   3. Repair a damaged repository when config or environment variables are set.
-    $ {{.HelpName}}
+    $ {{.FullName}}
 
 DOCUMENTATION:
 

--- a/command/repo/sync.go
+++ b/command/repo/sync.go
@@ -50,9 +50,9 @@ var CommandSync = &cli.Command{
 	CustomHelpTemplate: fmt.Sprintf(`%s
 	EXAMPLES:
 	1. Sync a single repo with SCM.
-	  $ {{.HelpName}} --org MyOrg --repo MyRepo
+	  $ {{.FullName}} --org MyOrg --repo MyRepo
 	2. Sync every repo within an org
-	  $ {{.HelpName}} --org MyOrg --all
+	  $ {{.FullName}} --org MyOrg --all
   
     DOCUMENTATION:
   

--- a/command/repo/update.go
+++ b/command/repo/update.go
@@ -136,17 +136,17 @@ var CommandUpdate = &cli.Command{
 	CustomHelpTemplate: fmt.Sprintf(`%s
 EXAMPLES:
   1. Update a repository with push and pull request enabled.
-    $ {{.HelpName}} --org MyOrg --repo MyRepo --event push --event pull_request
+    $ {{.FullName}} --org MyOrg --repo MyRepo --event push --event pull_request
   2. Update a repository with all event types enabled.
-    $ {{.HelpName}} --org MyOrg --repo MyRepo --event push,pull_request,tag,deployment,comment
+    $ {{.FullName}} --org MyOrg --repo MyRepo --event push,pull_request,tag,deployment,comment
   3. Update a repository with a longer build timeout.
-    $ {{.HelpName}} --org MyOrg --repo MyRepo --timeout 90
+    $ {{.FullName}} --org MyOrg --repo MyRepo --timeout 90
   4. Update a repository when config or environment variables are set.
-    $ {{.HelpName}}
+    $ {{.FullName}}
   5. Update a repository with a new build number.
-    $ {{.HelpName}} --org MyOrg --repo MyRepo --counter 200
+    $ {{.FullName}} --org MyOrg --repo MyRepo --counter 200
   6. Update a repository with approve build setting set to fork-always.
-    $ {{.HelpName}} --org MyOrg --repo MyRepo --approve-build fork-always
+    $ {{.FullName}} --org MyOrg --repo MyRepo --approve-build fork-always
 
 DOCUMENTATION:
 

--- a/command/repo/view.go
+++ b/command/repo/view.go
@@ -51,11 +51,11 @@ var CommandView = &cli.Command{
 	CustomHelpTemplate: fmt.Sprintf(`%s
 EXAMPLES:
   1. View details of a repository.
-    $ {{.HelpName}} --org MyOrg --repo MyRepo
+    $ {{.FullName}} --org MyOrg --repo MyRepo
   2. View details of a repository with json output.
-    $ {{.HelpName}} --org MyOrg --repo MyRepo --output json
+    $ {{.FullName}} --org MyOrg --repo MyRepo --output json
   3. View details of a repository when config or environment variables are set.
-    $ {{.HelpName}}
+    $ {{.FullName}}
 
 DOCUMENTATION:
 

--- a/command/schedule/add.go
+++ b/command/schedule/add.go
@@ -79,13 +79,13 @@ var CommandAdd = &cli.Command{
 	CustomHelpTemplate: fmt.Sprintf(`%s
 EXAMPLES:
   1. Add a schedule to a repository with active not enabled.
-    $ {{.HelpName}} --org MyOrg --repo MyRepo --schedule hourly --entry '0 * * * *' --active false
+    $ {{.FullName}} --org MyOrg --repo MyRepo --schedule hourly --entry '0 * * * *' --active false
   2. Add a schedule to a repository with a nightly entry.
-    $ {{.HelpName}} --org MyOrg --repo MyRepo --schedule nightly --entry '0 0 * * *'
+    $ {{.FullName}} --org MyOrg --repo MyRepo --schedule nightly --entry '0 0 * * *'
   3. Add a schedule to a repository with a weekly entry.
-    $ {{.HelpName}} --org MyOrg --repo MyRepo --schedule weekly --entry '@weekly'
+    $ {{.FullName}} --org MyOrg --repo MyRepo --schedule weekly --entry '@weekly'
   4. Add a schedule to a repository when config or environment variables are set.
-    $ {{.HelpName}}
+    $ {{.FullName}}
 
 DOCUMENTATION:
 

--- a/command/schedule/get.go
+++ b/command/schedule/get.go
@@ -68,15 +68,15 @@ var CommandGet = &cli.Command{
 	CustomHelpTemplate: fmt.Sprintf(`%s
 EXAMPLES:
   1. Get a list of schedules for a repository.
-    $ {{.HelpName}} --org MyOrg --repo MyRepo
+    $ {{.FullName}} --org MyOrg --repo MyRepo
   2. Get a list of schedules for a repository with wide view output.
-    $ {{.HelpName}} --org MyOrg --repo MyRepo --output wide
+    $ {{.FullName}} --org MyOrg --repo MyRepo --output wide
   3. Get a list of schedules for a repository with yaml output.
-    $ {{.HelpName}} --org MyOrg --repo MyRepo --output yaml
+    $ {{.FullName}} --org MyOrg --repo MyRepo --output yaml
   4. Get a list of schedules for a repository with json output.
-    $ {{.HelpName}} --org MyOrg --repo MyRepo --output json
+    $ {{.FullName}} --org MyOrg --repo MyRepo --output json
   5. Get a list of schedules for a repository when config or environment variables are set.
-    $ {{.HelpName}}
+    $ {{.FullName}}
 
 DOCUMENTATION:
 

--- a/command/schedule/remove.go
+++ b/command/schedule/remove.go
@@ -60,11 +60,11 @@ var CommandRemove = &cli.Command{
 	CustomHelpTemplate: fmt.Sprintf(`%s
 EXAMPLES:
   1. Remove a schedule from a repository.
-    $ {{.HelpName}} --org MyOrg --repo MyRepo --schedule daily
+    $ {{.FullName}} --org MyOrg --repo MyRepo --schedule daily
   2. Remove a schedule from a repository with json output.
-    $ {{.HelpName}} --org MyOrg --repo MyRepo --schedule daily --output json
+    $ {{.FullName}} --org MyOrg --repo MyRepo --schedule daily --output json
   3. Remove a schedule from a repository when config or environment variables are set.
-    $ {{.HelpName}}
+    $ {{.FullName}}
 
 DOCUMENTATION:
 

--- a/command/schedule/update.go
+++ b/command/schedule/update.go
@@ -79,11 +79,11 @@ var CommandUpdate = &cli.Command{
 	CustomHelpTemplate: fmt.Sprintf(`%s
 EXAMPLES:
   1. Update a schedule for a repository with active disabled.
-    $ {{.HelpName}} --org MyOrg --repo MyRepo --schedule hourly --active false
+    $ {{.FullName}} --org MyOrg --repo MyRepo --schedule hourly --active false
   2. Update a schedule for a repository with a new entry.
-    $ {{.HelpName}} --org MyOrg --repo MyRepo --schedule nightly --entry '@nightly'
+    $ {{.FullName}} --org MyOrg --repo MyRepo --schedule nightly --entry '@nightly'
   3. Update a schedule for a repository when config or environment variables are set.
-    $ {{.HelpName}}
+    $ {{.FullName}}
 
 DOCUMENTATION:
 

--- a/command/schedule/view.go
+++ b/command/schedule/view.go
@@ -60,11 +60,11 @@ var CommandView = &cli.Command{
 	CustomHelpTemplate: fmt.Sprintf(`%s
 EXAMPLES:
   1. View details of a schedule for a repository.
-    $ {{.HelpName}} --org MyOrg --repo MyRepo --schedule daily
+    $ {{.FullName}} --org MyOrg --repo MyRepo --schedule daily
   2. View details of a schedule for a repository with json output.
-    $ {{.HelpName}} --org MyOrg --repo MyRepo --schedule daily --output json
+    $ {{.FullName}} --org MyOrg --repo MyRepo --schedule daily --output json
   3. View details of a schedule for a repository when config or environment variables are set.
-    $ {{.HelpName}}
+    $ {{.FullName}}
 
 DOCUMENTATION:
 

--- a/command/secret/add.go
+++ b/command/secret/add.go
@@ -120,25 +120,25 @@ var CommandAdd = &cli.Command{
 	CustomHelpTemplate: fmt.Sprintf(`%s
 EXAMPLES:
    1. Add a repository secret.
-     $ {{.HelpName}} --secret.engine native --secret.type repo --org MyOrg --repo MyRepo --name foo --value bar
+     $ {{.FullName}} --secret.engine native --secret.type repo --org MyOrg --repo MyRepo --name foo --value bar
    2. Add a repository secret and disallow usage in commands.
-     $ {{.HelpName}} --secret.engine native --secret.type repo --org MyOrg --repo MyRepo --name foo --value bar --commands false
+     $ {{.FullName}} --secret.engine native --secret.type repo --org MyOrg --repo MyRepo --name foo --value bar --commands false
    3. Add an organization secret.
-     $ {{.HelpName}} --secret.engine native --secret.type org --org MyOrg --name foo --value bar
+     $ {{.FullName}} --secret.engine native --secret.type org --org MyOrg --name foo --value bar
    4. Add a shared secret.
-     $ {{.HelpName}} --secret.engine native --secret.type shared --org MyOrg --team octokitties --name foo --value bar
+     $ {{.FullName}} --secret.engine native --secret.type shared --org MyOrg --team octokitties --name foo --value bar
    5. Add a repository secret with all event types enabled.
-     $ {{.HelpName}} --secret.engine native --secret.type repo --org MyOrg --repo MyRepo --name foo --value bar --event comment --event deployment --event pull_request --event push --event tag
+     $ {{.FullName}} --secret.engine native --secret.type repo --org MyOrg --repo MyRepo --name foo --value bar --event comment --event deployment --event pull_request --event push --event tag
    6. Add a repository secret with an image whitelist.
-     $ {{.HelpName}} --secret.engine native --secret.type repo --org MyOrg --repo MyRepo --name foo --value bar --image alpine --image golang:* --image postgres:latest
+     $ {{.FullName}} --secret.engine native --secret.type repo --org MyOrg --repo MyRepo --name foo --value bar --image alpine --image golang:* --image postgres:latest
    7. Add a secret with value from a file.
-     $ {{.HelpName}} --secret.engine native --secret.type repo --org MyOrg --repo MyRepo --name foo --value @secret.txt
+     $ {{.FullName}} --secret.engine native --secret.type repo --org MyOrg --repo MyRepo --name foo --value @secret.txt
    8. Add a repository secret with json output.
-     $ {{.HelpName}} --secret.engine native --secret.type repo --org MyOrg --repo MyRepo --name foo --value bar --output json
+     $ {{.FullName}} --secret.engine native --secret.type repo --org MyOrg --repo MyRepo --name foo --value bar --output json
    9. Add a secret or secrets from a file.
-     $ {{.HelpName}} --file secret.yml
+     $ {{.FullName}} --file secret.yml
   10. Add a secret when config or environment variables are set.
-     $ {{.HelpName}} --org MyOrg --repo MyRepo --name foo --value bar
+     $ {{.FullName}} --org MyOrg --repo MyRepo --name foo --value bar
 
 DOCUMENTATION:
 

--- a/command/secret/get.go
+++ b/command/secret/get.go
@@ -92,17 +92,17 @@ var CommandGet = &cli.Command{
 	CustomHelpTemplate: fmt.Sprintf(`%s
 EXAMPLES:
   1. Get repository secret details.
-    $ {{.HelpName}} --secret.engine native --secret.type repo --org MyOrg --repo MyRepo
+    $ {{.FullName}} --secret.engine native --secret.type repo --org MyOrg --repo MyRepo
   2. Get organization secret details.
-    $ {{.HelpName}} --secret.engine native --secret.type org --org MyOrg
+    $ {{.FullName}} --secret.engine native --secret.type org --org MyOrg
   3. Get shared secret details for an organization.
-    $ {{.HelpName}} --secret.engine native --secret.type shared --org MyOrg --team '*'
+    $ {{.FullName}} --secret.engine native --secret.type shared --org MyOrg --team '*'
   4. Get shared secret details for a team.
-    $ {{.HelpName}} --secret.engine native --secret.type shared --org MyOrg --team octokitties
+    $ {{.FullName}} --secret.engine native --secret.type shared --org MyOrg --team octokitties
   5. Get repository secret details with json output.
-    $ {{.HelpName}} --secret.engine native --secret.type repo --org MyOrg --repo MyRepo --output json
+    $ {{.FullName}} --secret.engine native --secret.type repo --org MyOrg --repo MyRepo --output json
   6. Get secret details when config or environment variables are set.
-    $ {{.HelpName}} --org MyOrg --repo MyRepo
+    $ {{.FullName}} --org MyOrg --repo MyRepo
 
 DOCUMENTATION:
 

--- a/command/secret/remove.go
+++ b/command/secret/remove.go
@@ -81,15 +81,15 @@ var CommandRemove = &cli.Command{
 	CustomHelpTemplate: fmt.Sprintf(`%s
 EXAMPLES:
   1. Remove repository secret details.
-    $ {{.HelpName}} --secret.engine native --secret.type repo --org MyOrg --repo MyRepo --name foo
+    $ {{.FullName}} --secret.engine native --secret.type repo --org MyOrg --repo MyRepo --name foo
   2. Remove organization secret details.
-    $ {{.HelpName}} --secret.engine native --secret.type org --org MyOrg --name foo
+    $ {{.FullName}} --secret.engine native --secret.type org --org MyOrg --name foo
   3. Remove shared secret details.
-    $ {{.HelpName}} --secret.engine native --secret.type shared --org MyOrg --team octokitties --name foo
+    $ {{.FullName}} --secret.engine native --secret.type shared --org MyOrg --team octokitties --name foo
   4. Remove repository secret details with json output.
-    $ {{.HelpName}} --secret.engine native --secret.type repo --org MyOrg --repo MyRepo --name foo --output json
+    $ {{.FullName}} --secret.engine native --secret.type repo --org MyOrg --repo MyRepo --name foo --output json
   5. Remove secret details when config or environment variables are set.
-    $ {{.HelpName}} --org MyOrg --repo MyRepo --name foo
+    $ {{.FullName}} --org MyOrg --repo MyRepo --name foo
 
 DOCUMENTATION:
 

--- a/command/secret/update.go
+++ b/command/secret/update.go
@@ -120,25 +120,25 @@ var CommandUpdate = &cli.Command{
 	CustomHelpTemplate: fmt.Sprintf(`%s
 EXAMPLES:
    1. Update a repository secret.
-     $ {{.HelpName}} --secret.engine native --secret.type repo --org MyOrg --repo MyRepo --name foo --value bar
+     $ {{.FullName}} --secret.engine native --secret.type repo --org MyOrg --repo MyRepo --name foo --value bar
    2. Update a repository secret and disallow usage in commands.
-     $ {{.HelpName}} --secret.engine native --secret.type repo --org MyOrg --repo MyRepo --name foo --value bar --commands false
+     $ {{.FullName}} --secret.engine native --secret.type repo --org MyOrg --repo MyRepo --name foo --value bar --commands false
    3. Update an organization secret.
-     $ {{.HelpName}} --secret.engine native --secret.type org --org MyOrg --name foo --value bar
+     $ {{.FullName}} --secret.engine native --secret.type org --org MyOrg --name foo --value bar
    4. Update a shared secret.
-     $ {{.HelpName}} --secret.engine native --secret.type shared --org MyOrg --team octokitties --name foo --value bar
+     $ {{.FullName}} --secret.engine native --secret.type shared --org MyOrg --team octokitties --name foo --value bar
    5. Update a repository secret with all event types enabled.
-     $ {{.HelpName}} --secret.engine native --secret.type repo --org MyOrg --repo MyRepo --name foo --event comment --event deployment --event pull_request --event push --event tag
+     $ {{.FullName}} --secret.engine native --secret.type repo --org MyOrg --repo MyRepo --name foo --event comment --event deployment --event pull_request --event push --event tag
    6. Update a repository secret with an image whitelist.
-     $ {{.HelpName}} --secret.engine native --secret.type repo --org MyOrg --repo MyRepo --name foo --image alpine --image golang:* --image postgres:latest
+     $ {{.FullName}} --secret.engine native --secret.type repo --org MyOrg --repo MyRepo --name foo --image alpine --image golang:* --image postgres:latest
    7. Update a secret with value from a file.
-     $ {{.HelpName}} --secret.engine native --secret.type repo --org MyOrg --repo MyRepo --name foo --value @secret.txt
+     $ {{.FullName}} --secret.engine native --secret.type repo --org MyOrg --repo MyRepo --name foo --value @secret.txt
    8. Update a repository secret with json output.
-     $ {{.HelpName}} --secret.engine native --secret.type repo --org MyOrg --repo MyRepo --name foo --value bar --output json
+     $ {{.FullName}} --secret.engine native --secret.type repo --org MyOrg --repo MyRepo --name foo --value bar --output json
    9. Update a secret or secrets from a file.
-     $ {{.HelpName}} --file secret.yml
+     $ {{.FullName}} --file secret.yml
   10. Update a secret when config or environment variables are set.
-     $ {{.HelpName}} --org MyOrg --repo MyRepo --name foo --value bar
+     $ {{.FullName}} --org MyOrg --repo MyRepo --name foo --value bar
 
 DOCUMENTATION:
 

--- a/command/secret/view.go
+++ b/command/secret/view.go
@@ -81,15 +81,15 @@ var CommandView = &cli.Command{
 	CustomHelpTemplate: fmt.Sprintf(`%s
 EXAMPLES:
   1. View repository secret details.
-    $ {{.HelpName}} --secret.engine native --secret.type repo --org MyOrg --repo MyRepo --name foo
+    $ {{.FullName}} --secret.engine native --secret.type repo --org MyOrg --repo MyRepo --name foo
   2. View organization secret details.
-    $ {{.HelpName}} --secret.engine native --secret.type org --org MyOrg --name foo
+    $ {{.FullName}} --secret.engine native --secret.type org --org MyOrg --name foo
   3. View shared secret details.
-    $ {{.HelpName}} --secret.engine native --secret.type shared --org MyOrg --team octokitties --name foo
+    $ {{.FullName}} --secret.engine native --secret.type shared --org MyOrg --team octokitties --name foo
   4. View repository secret details with json output.
-    $ {{.HelpName}} --secret.engine native --secret.type repo --org MyOrg --repo MyRepo --name foo --output json
+    $ {{.FullName}} --secret.engine native --secret.type repo --org MyOrg --repo MyRepo --name foo --output json
   5. View secret details when config or environment variables are set.
-    $ {{.HelpName}} --org MyOrg --repo MyRepo --name foo
+    $ {{.FullName}} --org MyOrg --repo MyRepo --name foo
 
 DOCUMENTATION:
 

--- a/command/service/get.go
+++ b/command/service/get.go
@@ -77,15 +77,15 @@ var CommandGet = &cli.Command{
 	CustomHelpTemplate: fmt.Sprintf(`%s
 EXAMPLES:
   1. Get services for a repository.
-    $ {{.HelpName}} --org MyOrg --repo MyRepo --build 1
+    $ {{.FullName}} --org MyOrg --repo MyRepo --build 1
   2. Get services for a repository with wide view output.
-    $ {{.HelpName}} --org MyOrg --repo MyRepo --build 1 --output wide
+    $ {{.FullName}} --org MyOrg --repo MyRepo --build 1 --output wide
   3. Get services for a repository with yaml output.
-    $ {{.HelpName}} --org MyOrg --repo MyRepo --build 1 --output yaml
+    $ {{.FullName}} --org MyOrg --repo MyRepo --build 1 --output yaml
   4. Get services for a repository with json output.
-    $ {{.HelpName}} --org MyOrg --repo MyRepo --build 1 --output json
+    $ {{.FullName}} --org MyOrg --repo MyRepo --build 1 --output json
   5. Get services for a build when config or environment variables are set.
-    $ {{.HelpName}} --build 1
+    $ {{.FullName}} --build 1
 
 DOCUMENTATION:
 

--- a/command/service/view.go
+++ b/command/service/view.go
@@ -69,11 +69,11 @@ var CommandView = &cli.Command{
 	CustomHelpTemplate: fmt.Sprintf(`%s
 EXAMPLES:
   1. View service details for a repository.
-    $ {{.HelpName}} --org MyOrg --repo MyRepo --build 1 --service 1
+    $ {{.FullName}} --org MyOrg --repo MyRepo --build 1 --service 1
   2. View service details for a repository with json output.
-    $ {{.HelpName}} --org MyOrg --repo MyRepo --build 1 --service 1 --output json
+    $ {{.FullName}} --org MyOrg --repo MyRepo --build 1 --service 1 --output json
   3. View service details for a repository when config or environment variables are set.
-    $ {{.HelpName}} --build 1 --service 1
+    $ {{.FullName}} --build 1 --service 1
 
 DOCUMENTATION:
 

--- a/command/settings/update.go
+++ b/command/settings/update.go
@@ -159,21 +159,21 @@ var CommandUpdate = &cli.Command{
 	CustomHelpTemplate: fmt.Sprintf(`%s
 EXAMPLES:
   1. Update settings to change the compiler clone image to target/vela-git:latest.
-    $ {{.HelpName}} --compiler.clone-image target/vela-git:latest
+    $ {{.FullName}} --compiler.clone-image target/vela-git:latest
   2. Update settings to change the compiler template depth to 2.
-    $ {{.HelpName}} --compiler.template-depth 2
+    $ {{.FullName}} --compiler.template-depth 2
   3. Update settings to change the compiler starlark exec limit to 5.
-    $ {{.HelpName}} --compiler.starlark-exec-limit 5
+    $ {{.FullName}} --compiler.starlark-exec-limit 5
   4. Update settings with additional queue routes.
-    $ {{.HelpName}} --queue.add-route large --queue.add-route small
+    $ {{.FullName}} --queue.add-route large --queue.add-route small
   5. Update settings by dropping queue routes.
-    $ {{.HelpName}} --queue.drop-route large --queue.drop-route small
+    $ {{.FullName}} --queue.drop-route large --queue.drop-route small
   6. Update settings with additional repos permitted to use Vela (patterns containing * wildcards must be wrapped in quotes on the commandline).
-    $ {{.HelpName}} --add-repo octocat/hello-world --add-repo 'octocat/*'
+    $ {{.FullName}} --add-repo octocat/hello-world --add-repo 'octocat/*'
   7. Update settings with additional repos permitted to use schedules in Vela (patterns containing * wildcards must be wrapped in quotes on the commandline).
-    $ {{.HelpName}} --add-schedule octocat/hello-world --schedule 'octocat/*'
+    $ {{.FullName}} --add-schedule octocat/hello-world --schedule 'octocat/*'
   8. Update settings from a file.
-    $ {{.HelpName}} --file settings.yml
+    $ {{.FullName}} --file settings.yml
 DOCUMENTATION:
 
   https://go-vela.github.io/docs/reference/cli/settings/update/

--- a/command/settings/view.go
+++ b/command/settings/view.go
@@ -37,7 +37,7 @@ var CommandView = &cli.Command{
 	CustomHelpTemplate: fmt.Sprintf(`%s
 EXAMPLES:
   1. View platform settings.
-    $ {{.HelpName}}
+    $ {{.FullName}}
 
 DOCUMENTATION:
 

--- a/command/step/get.go
+++ b/command/step/get.go
@@ -77,15 +77,15 @@ var CommandGet = &cli.Command{
 	CustomHelpTemplate: fmt.Sprintf(`%s
 EXAMPLES:
   1. Get steps for a repository.
-    $ {{.HelpName}} --org MyOrg --repo MyRepo --build 1
+    $ {{.FullName}} --org MyOrg --repo MyRepo --build 1
   2. Get steps for a repository with wide view output.
-    $ {{.HelpName}} --org MyOrg --repo MyRepo --build 1 --output wide
+    $ {{.FullName}} --org MyOrg --repo MyRepo --build 1 --output wide
   3. Get steps for a repository with yaml output.
-    $ {{.HelpName}} --org MyOrg --repo MyRepo --build 1 --output yaml
+    $ {{.FullName}} --org MyOrg --repo MyRepo --build 1 --output yaml
   4. Get steps for a repository with json output.
-    $ {{.HelpName}} --org MyOrg --repo MyRepo --build 1 --output json
+    $ {{.FullName}} --org MyOrg --repo MyRepo --build 1 --output json
   5. Get steps for a build when config or environment variables are set.
-    $ {{.HelpName}} --build 1
+    $ {{.FullName}} --build 1
 
 DOCUMENTATION:
 

--- a/command/step/view.go
+++ b/command/step/view.go
@@ -69,11 +69,11 @@ var CommandView = &cli.Command{
 	CustomHelpTemplate: fmt.Sprintf(`%s
 EXAMPLES:
   1. View step details for a repository.
-    $ {{.HelpName}} --org MyOrg --repo MyRepo --build 1 --step 1
+    $ {{.FullName}} --org MyOrg --repo MyRepo --build 1 --step 1
   2. View step details for a repository with json output.
-    $ {{.HelpName}} --org MyOrg --repo MyRepo --build 1 --step 1 --output json
+    $ {{.FullName}} --org MyOrg --repo MyRepo --build 1 --step 1 --output json
   3. View step details for a repository config or environment variables are set.
-    $ {{.HelpName}} --build 1 --step 1
+    $ {{.FullName}} --build 1 --step 1
 
 DOCUMENTATION:
 

--- a/command/user/update.go
+++ b/command/user/update.go
@@ -63,13 +63,13 @@ var CommandUpdate = &cli.Command{
 	CustomHelpTemplate: fmt.Sprintf(`%s
 EXAMPLES:
   1. Update current user to add a repository to favorites.
-    $ {{.HelpName}} --add-favorites Org-1/Repo-1
+    $ {{.FullName}} --add-favorites Org-1/Repo-1
   2. Update current user to remove a repository from favorites.
-    $ {{.HelpName}} --drop-favorites Org-1/Repo-1
+    $ {{.FullName}} --drop-favorites Org-1/Repo-1
   3. Update current user to add a dashboard.
-    $ {{.HelpName}} --add-dashboards c8da1302-07d6-11ea-882f-4893bca275b8
+    $ {{.FullName}} --add-dashboards c8da1302-07d6-11ea-882f-4893bca275b8
   4. Update current user to remove a dashboard.
-    $ {{.HelpName}} --drop-dashboards c8da1302-07d6-11ea-882f-4893bca275b8
+    $ {{.FullName}} --drop-dashboards c8da1302-07d6-11ea-882f-4893bca275b8
 
 DOCUMENTATION:
 

--- a/command/user/view.go
+++ b/command/user/view.go
@@ -45,11 +45,11 @@ var CommandView = &cli.Command{
 	CustomHelpTemplate: fmt.Sprintf(`%s
 EXAMPLES:
   1. View details of the current user.
-    $ {{.HelpName}}
+    $ {{.FullName}}
   2. View details of another user (admin).
-    $ {{.HelpName}} --name Octocat
+    $ {{.FullName}} --name Octocat
   3. View details of current user with json output.
-    $ {{.HelpName}} --output json
+    $ {{.FullName}} --output json
 
 DOCUMENTATION:
 

--- a/command/version/version.go
+++ b/command/version/version.go
@@ -34,9 +34,9 @@ var CommandVersion = &cli.Command{
 	CustomHelpTemplate: fmt.Sprintf(`%s
 EXAMPLES:
   1. Output Vela version information
-    $ {{.HelpName}}
+    $ {{.FullName}}
   2. Output Vela version information with JSON output
-    $ {{.HelpName}} --output json
+    $ {{.FullName}} --output json
 
 DOCUMENTATION:
 

--- a/command/worker/add.go
+++ b/command/worker/add.go
@@ -52,9 +52,9 @@ var CommandAdd = &cli.Command{
 	CustomHelpTemplate: fmt.Sprintf(`%s
 EXAMPLES:
   1. Add a worker reachable at the provided address.
-    $ {{.HelpName}} --worker.address https://myworker.example.com
+    $ {{.FullName}} --worker.address https://myworker.example.com
   2. Add a worker reachable at the provided address with specific hostname.
-    $ {{.HelpName}} --worker.hostname MyWorker --worker.address https://myworker.example.com
+    $ {{.FullName}} --worker.hostname MyWorker --worker.address https://myworker.example.com
 
 DOCUMENTATION:
 

--- a/command/worker/get.go
+++ b/command/worker/get.go
@@ -61,15 +61,15 @@ var CommandGet = &cli.Command{
 	CustomHelpTemplate: fmt.Sprintf(`%s
 EXAMPLES:
   1. Get a list of workers.
-    $ {{.HelpName}}
+    $ {{.FullName}}
   2. Get a list of workers with wide view output.
-    $ {{.HelpName}} --output wide
+    $ {{.FullName}} --output wide
   3. Get a list of workers with yaml output.
-    $ {{.HelpName}} --output yaml
+    $ {{.FullName}} --output yaml
   4. Get a list of workers with json output.
-    $ {{.HelpName}} --output json
+    $ {{.FullName}} --output json
   5. Get a list of workers when config or environment variables are set.
-    $ {{.HelpName}}
+    $ {{.FullName}}
 
 DOCUMENTATION:
 

--- a/command/worker/update.go
+++ b/command/worker/update.go
@@ -68,9 +68,9 @@ var CommandUpdate = &cli.Command{
 	CustomHelpTemplate: fmt.Sprintf(`%s
 EXAMPLES:
   1. Update a worker to change its build limit to 2.
-    $ {{.HelpName}} --worker.hostname MyWorker --build-limit 2
+    $ {{.FullName}} --worker.hostname MyWorker --build-limit 2
   2. Update a worker with custom routes.
-    $ {{.HelpName}} --worker.hostname MyWorker --route large --route small
+    $ {{.FullName}} --worker.hostname MyWorker --route large --route small
 
 DOCUMENTATION:
 

--- a/command/worker/view.go
+++ b/command/worker/view.go
@@ -52,13 +52,13 @@ var CommandView = &cli.Command{
 	CustomHelpTemplate: fmt.Sprintf(`%s
 EXAMPLES:
   1. View details of a worker.
-    $ {{.HelpName}} --worker.hostname MyWorker
+    $ {{.FullName}} --worker.hostname MyWorker
   2. View registration token for a worker.
-    $ {{.HelpName}} --worker.hostname MyWorker --worker.registration.token true
+    $ {{.FullName}} --worker.hostname MyWorker --worker.registration.token true
   3. View details of a worker with json output.
-    $ {{.HelpName}} --worker.hostname MyWorker --output json
+    $ {{.FullName}} --worker.hostname MyWorker --output json
   4. View details of a worker when config or environment variables are set.
-    $ {{.HelpName}}
+    $ {{.FullName}}
 
 DOCUMENTATION:
 


### PR DESCRIPTION
another surprise. the `urfave/cli` upgrade to v3 caused our custom help template to not render because a variable we were using doesn't exist anymore. it was rendering as such (example from `vela view repo --help`):

![image](https://github.com/user-attachments/assets/915d3857-f627-4bd0-b1e4-9d1a18098b59)

