### PR TITLE
fix(renovate): use go-vela/server setup to manage image updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -11,7 +11,7 @@
         "/\\.go$/"
       ],
       "matchStrings": [
-        "Value:\\s+\"(?<depName>[^:\"]+):(?<currentValue>[^@\"]+)(@(?<currentDigest>sha256:[a-f0-9]+))?\""
+        "\"(?<depName>.*?):(?<currentValue>[^\"]*?)@(?<currentDigest>sha256:[a-f0-9]+)\",? // renovate: container"
       ],
       "datasourceTemplate": "docker"
     }

--- a/command/pipeline/exec.go
+++ b/command/pipeline/exec.go
@@ -179,13 +179,13 @@ var CommandExec = &cli.Command{
 			Sources: cli.EnvVars("VELA_CLONE_IMAGE", "COMPILER_CLONE_IMAGE"),
 			Name:    "clone-image",
 			Usage:   "the clone image to use for the injected clone step",
-			Value:   "docker.io/target/vela-git-slim:v0.12.0@sha256:533786ab3ef17c900b0105fdffbd7143d2601803f28b39e156132ad25819af0f",
+			Value:   "docker.io/target/vela-git-slim:v0.12.0@sha256:533786ab3ef17c900b0105fdffbd7143d2601803f28b39e156132ad25819af0f", // renovate: container
 		},
 		&cli.StringFlag{
 			Sources: cli.EnvVars("VELA_OUTPUTS_IMAGE", "EXECUTOR_OUTPUTS_IMAGE"),
 			Name:    "outputs-image",
 			Usage:   "the outputs image to use for the build",
-			Value:   "docker.io/library/alpine:3.21.3@sha256:a8560b36e8b8210634f77d9f7f9efd7ffa463e380b75e2e74aff4511df3ef88c",
+			Value:   "docker.io/library/alpine:3.21.3@sha256:a8560b36e8b8210634f77d9f7f9efd7ffa463e380b75e2e74aff4511df3ef88c", // renovate: container
 		},
 
 		// Environment Flags

--- a/command/pipeline/validate.go
+++ b/command/pipeline/validate.go
@@ -178,7 +178,7 @@ var CommandValidate = &cli.Command{
 			Sources:  cli.EnvVars("VELA_CLONE_IMAGE", "COMPILER_CLONE_IMAGE"),
 			Name:     "clone-image",
 			Usage:    "the clone image to use for the injected clone step",
-			Value:    "docker.io/target/vela-git-slim:v0.12.0@sha256:533786ab3ef17c900b0105fdffbd7143d2601803f28b39e156132ad25819af0f",
+			Value:    "docker.io/target/vela-git-slim:v0.12.0@sha256:533786ab3ef17c900b0105fdffbd7143d2601803f28b39e156132ad25819af0f", // renovate: container
 			Category: "4. Compiler:",
 		},
 	},


### PR DESCRIPTION
https://github.com/go-vela/cli/pull/606 failed (see https://github.com/go-vela/cli/issues/255). the problem seems to be that it picks up values that we don't care to update inside `Value: "<image>"`, which didn't surface in local testing (unless i missed it). in this approach we're just copying [what we do on the server](https://github.com/go-vela/server/blob/0e450d5055d6b4d03f82e5b2fef1afc116e61b94/.github/renovate.json#L14) which has been working; we just have to add a comment for renovate to identify the values we care about.