### PR TITLE
fix(color): no color for non-terminal

### DIFF
--- a/internal/output/color.go
+++ b/internal/output/color.go
@@ -4,10 +4,12 @@ package output
 
 import (
 	"bytes"
+	"os"
 
 	chroma "github.com/alecthomas/chroma/v2/quick"
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli/v3"
+	"golang.org/x/term"
 
 	"github.com/go-vela/cli/internal"
 )
@@ -28,6 +30,11 @@ func ColorOptionsFromCLIContext(c *cli.Command) ColorOptions {
 	}
 
 	opts.Enabled = internal.StringToBool(c.String(internal.FlagColor))
+
+	// if it's not a terminal, don't use color
+	if !term.IsTerminal(int(os.Stdout.Fd())) {
+		opts.Enabled = false
+	}
 
 	if c.IsSet(internal.FlagColorFormat) {
 		opts.Format = c.String(internal.FlagColorFormat)


### PR DESCRIPTION
fixes https://github.com/go-vela/community/issues/1056

avoids issues when you have color output enabled but are sending output to non-terminal. example:

`$ vela --color true view repo --org <org> --repo <repo> --output json | jq -r '.'`

currently results in:

`jq: parse error: Invalid numeric literal at line 1, column 2`

due to color codes in response. this simple fix overrides color output in such instances so users don't have to manually strip color code prior to working with the data when piping to other utils.