### PR TITLE
chore(deps): use go.yaml.in/yaml/v3

### DIFF
--- a/action/config/generate.go
+++ b/action/config/generate.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/afero"
-	yaml "gopkg.in/yaml.v3"
+	yaml "go.yaml.in/yaml/v3"
 )
 
 // create filesystem based on the operating system

--- a/action/config/load.go
+++ b/action/config/load.go
@@ -8,7 +8,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/afero"
 	"github.com/urfave/cli/v3"
-	yaml "gopkg.in/yaml.v3"
+	yaml "go.yaml.in/yaml/v3"
 
 	"github.com/go-vela/cli/internal"
 )
@@ -50,8 +50,6 @@ func (c *Config) Load(cmd *cli.Command) error {
 	config := new(ConfigFile)
 
 	// update the config object with the current content
-	//
-	// https://pkg.go.dev/gopkg.in/yaml.v3?tab=doc#Unmarshal
 	err = yaml.Unmarshal(data, config)
 	if err != nil {
 		return err

--- a/action/config/remove.go
+++ b/action/config/remove.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/afero"
-	yaml "gopkg.in/yaml.v3"
+	yaml "go.yaml.in/yaml/v3"
 
 	"github.com/go-vela/cli/internal"
 )
@@ -62,8 +62,6 @@ func (c *Config) Remove() error {
 	config := new(ConfigFile)
 
 	// update the config object with the current content
-	//
-	// https://pkg.go.dev/gopkg.in/yaml.v3?tab=doc#Unmarshal
 	err = yaml.Unmarshal(data, config)
 	if err != nil {
 		return err
@@ -179,8 +177,6 @@ func (c *Config) Remove() error {
 	logrus.Trace("creating file content for config file")
 
 	// create output for config file
-	//
-	// https://pkg.go.dev/gopkg.in/yaml.v3?tab=doc#Marshal
 	out, err := yaml.Marshal(config)
 	if err != nil {
 		return err

--- a/action/config/update.go
+++ b/action/config/update.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/afero"
-	yaml "gopkg.in/yaml.v3"
+	yaml "go.yaml.in/yaml/v3"
 
 	"github.com/go-vela/cli/internal"
 	"github.com/go-vela/sdk-go/vela"
@@ -52,8 +52,6 @@ func (c *Config) Update() error {
 	config := new(ConfigFile)
 
 	// update the config object with the current content
-	//
-	// https://pkg.go.dev/gopkg.in/yaml.v3?tab=doc#Unmarshal
 	err = yaml.Unmarshal(data, config)
 	if err != nil {
 		return err
@@ -173,8 +171,6 @@ func (c *Config) Update() error {
 	logrus.Trace("creating file content for config file")
 
 	// create output for config file
-	//
-	// https://pkg.go.dev/gopkg.in/yaml.v3?tab=doc#Marshal
 	out, err := yaml.Marshal(config)
 	if err != nil {
 		return err

--- a/action/pipeline/generate.go
+++ b/action/pipeline/generate.go
@@ -6,9 +6,9 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/buildkite/yaml"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/afero"
+	"go.yaml.in/yaml/v3"
 )
 
 // create filesystem based on the operating system
@@ -31,8 +31,6 @@ func (c *Config) Generate() error {
 	logrus.Trace("creating file content from pipeline")
 
 	// create output for pipeline file
-	//
-	// https://pkg.go.dev/github.com/buildkite/yaml?tab=doc#Marshal
 	out, err := yaml.Marshal(pipeline)
 	if err != nil {
 		return err

--- a/action/secret/add.go
+++ b/action/secret/add.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 
 	"github.com/sirupsen/logrus"
-	yaml "gopkg.in/yaml.v3"
+	yaml "go.yaml.in/yaml/v3"
 
 	"github.com/go-vela/cli/internal/output"
 	"github.com/go-vela/sdk-go/vela"
@@ -128,8 +128,6 @@ func (c *Config) AddFromFile(client *vela.Client) error {
 	}
 
 	// create a new decoder from the secret file contents
-	//
-	// https://pkg.go.dev/gopkg.in/yaml.v3?tab=doc#NewDecoder
 	input := yaml.NewDecoder(bytes.NewReader(contents))
 
 	// create object to store secret file configuration
@@ -138,8 +136,6 @@ func (c *Config) AddFromFile(client *vela.Client) error {
 	f := new(ConfigFile)
 
 	// iterate through all secret file configurations
-	//
-	// https://pkg.go.dev/gopkg.in/yaml.v3?tab=doc#Decoder.Decode
 	for input.Decode(f) == nil {
 		// iterate through all secrets from the file configuration
 		for _, s := range f.Secrets {

--- a/action/secret/update.go
+++ b/action/secret/update.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 
 	"github.com/sirupsen/logrus"
-	yaml "gopkg.in/yaml.v3"
+	yaml "go.yaml.in/yaml/v3"
 
 	"github.com/go-vela/cli/internal/output"
 	"github.com/go-vela/sdk-go/vela"
@@ -126,8 +126,6 @@ func (c *Config) UpdateFromFile(client *vela.Client) error {
 	}
 
 	// create a new decoder from the secret file contents
-	//
-	// https://pkg.go.dev/gopkg.in/yaml.v3?tab=doc#NewDecoder
 	input := yaml.NewDecoder(bytes.NewReader(contents))
 
 	// create object to store secret file configuration
@@ -136,8 +134,6 @@ func (c *Config) UpdateFromFile(client *vela.Client) error {
 	f := new(ConfigFile)
 
 	// iterate through all secret file configurations
-	//
-	// https://pkg.go.dev/gopkg.in/yaml.v3?tab=doc#Decoder.Decode
 	for input.Decode(f) == nil {
 		// iterate through all secrets from the file configuration
 		for _, s := range f.Secrets {

--- a/action/secret/view.go
+++ b/action/secret/view.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 
 	"github.com/sirupsen/logrus"
-	yaml "gopkg.in/yaml.v3"
+	yaml "go.yaml.in/yaml/v3"
 
 	"github.com/go-vela/cli/internal/output"
 	"github.com/go-vela/sdk-go/vela"

--- a/action/settings/update.go
+++ b/action/settings/update.go
@@ -10,7 +10,7 @@ import (
 	"slices"
 
 	"github.com/sirupsen/logrus"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 
 	"github.com/go-vela/cli/internal"
 	"github.com/go-vela/cli/internal/output"

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,6 @@ go 1.24.4
 require (
 	github.com/Masterminds/semver/v3 v3.4.0
 	github.com/alecthomas/chroma/v2 v2.19.0
-	github.com/buildkite/yaml v0.0.0-20230306222819-0e4e032d4835
 	github.com/chainguard-dev/git-urls v1.0.2
 	github.com/cli/browser v1.3.0
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc
@@ -23,8 +22,8 @@ require (
 	github.com/spf13/afero v1.14.0
 	github.com/urfave/cli-docs/v3 v3.0.0-alpha6
 	github.com/urfave/cli/v3 v3.3.8
+	go.yaml.in/yaml/v3 v3.0.4
 	golang.org/x/term v0.32.0
-	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
@@ -39,6 +38,7 @@ require (
 	github.com/aymerick/douceur v0.2.0 // indirect
 	github.com/bahlo/generic-list-go v0.2.0 // indirect
 	github.com/buger/jsonparser v1.1.1 // indirect
+	github.com/buildkite/yaml v0.0.0-20230306222819-0e4e032d4835 // indirect
 	github.com/bytedance/sonic v1.13.3 // indirect
 	github.com/bytedance/sonic/loader v0.2.4 // indirect
 	github.com/cenkalti/backoff/v5 v5.0.2 // indirect
@@ -159,7 +159,6 @@ require (
 	go.opentelemetry.io/proto/otlp v1.7.0 // indirect
 	go.starlark.net v0.0.0-20250701195324-d457b4515e0e // indirect
 	go.yaml.in/yaml/v2 v2.4.2 // indirect
-	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/arch v0.18.0 // indirect
 	golang.org/x/crypto v0.39.0 // indirect
 	golang.org/x/net v0.41.0 // indirect
@@ -176,6 +175,7 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 	gorm.io/driver/postgres v1.6.0 // indirect
 	gorm.io/driver/sqlite v1.6.0 // indirect
 	gorm.io/gorm v1.30.0 // indirect

--- a/internal/output/yaml.go
+++ b/internal/output/yaml.go
@@ -7,7 +7,7 @@ import (
 	"os"
 
 	"github.com/sirupsen/logrus"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 // YAML parses the provided input and


### PR DESCRIPTION
drops direct dependencies of deprecated yaml packages. see https://github.com/go-vela/server/commit/91ba0d571a96b953009c70b466febf316167934d for similar change.